### PR TITLE
postfix::config: don't work if value is something like "[1.2.3.4]"

### DIFF
--- a/manifests/definitions/config.pp
+++ b/manifests/definitions/config.pp
@@ -37,13 +37,13 @@ define postfix::config ($ensure = present, $value) {
 
   case $ensure {
     present: {
-      augeas { "set postfix $name to $value":
+      augeas { "set postfix '${name}' to '${value}'":
         changes => "set $name $value",
       }
     }
 
     absent: {
-      augeas { "set postfix $name to $value":
+      augeas { "rm postfix '${name}'":
         changes => "rm $name",
       }
     }


### PR DESCRIPTION
For instance::
    postfix::config { "relayhost": value  => "[10.1.2.3]" }
