### PR TITLE
Make mynetworks configurable

### DIFF
--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -40,11 +40,15 @@ class postfix::mta {
     "": { $postfix_mydestination = "\$myorigin" }
   }
 
+  case $postfix_mynetworks {
+    "": { $postfix_mynetworks = "127.0.0.0/8" }
+  }
+
   include postfix
 
   postfix::config {
     "mydestination":                        value => $postfix_mydestination;
-    "mynetworks":                           value => "127.0.0.0/8";
+    "mynetworks":                           value => $postfix_mynetworks;
     "relayhost":                            value => $postfix_relayhost;
     "virtual_alias_maps":                   value => "hash:/etc/postfix/virtual";
     "transport_maps":                       value => "hash:/etc/postfix/transport";


### PR DESCRIPTION
Currently the `mynetworks` postfix parameter is hardcoded to `"127.0.0.0/8"`.
This patch allows to set it to a different value via the `$postfix_mynetworks` parameter.
The default value is still `"127.0.0.0/8"`.

This might be useful for other people as well :-)
