### PR TITLE
Make module puppet style guide compliant

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,38 +1,38 @@
-/*
-== Definition: postfix::config
-
-Uses the "postconf" command to add/alter/remove options in postfix main
-configuation file (/etc/postfix/main.cf).
-
-Parameters:
-- *name*: name of the parameter.
-- *ensure*: present/absent. defaults to present.
-- *value*: value of the parameter.
-
-Requires:
-- Class["postfix"]
-
-Example usage:
-
-  node "toto.example.com" {
-
-    include postfix
-
-    postfix::config {
-      "smtp_use_tls"            => "yes";
-      "smtp_sasl_auth_enable"   => "yes";
-      "smtp_sasl_password_maps" => "hash:/etc/postfix/my_sasl_passwords";
-      "relayhost"               => "[mail.example.com]:587";
-    }
-  }
-
-*/
-define postfix::config ($ensure = present, $value) {
+#
+#== Definition: postfix::config
+#
+#Uses the "postconf" command to add/alter/remove options in postfix main
+#configuation file (/etc/postfix/main.cf).
+#
+#Parameters:
+#- *name*: name of the parameter.
+#- *ensure*: present/absent. defaults to present.
+#- *value*: value of the parameter.
+#
+#Requires:
+#- Class["postfix"]
+#
+#Example usage:
+#
+#  node "toto.example.com" {
+#
+#    include postfix
+#
+#    postfix::config {
+#      "smtp_use_tls"            => "yes";
+#      "smtp_sasl_auth_enable"   => "yes";
+#      "smtp_sasl_password_maps" => "hash:/etc/postfix/my_sasl_passwords";
+#      "relayhost"               => "[mail.example.com]:587";
+#    }
+#  }
+#
+#
+define postfix::config ($value, $ensure = present) {
 
   Augeas {
-    context => "/files/etc/postfix/main.cf",
-    notify  => Service["postfix"],
-    require => File["/etc/postfix/main.cf"],
+    context => '/files/etc/postfix/main.cf',
+    notify  => Service['postfix'],
+    require => File['/etc/postfix/main.cf'],
   }
 
   case $ensure {
@@ -41,11 +41,11 @@ define postfix::config ($ensure = present, $value) {
         changes => "set $name $value",
       }
     }
-
     absent: {
       augeas { "rm postfix '${name}'":
         changes => "rm $name",
       }
     }
+    default: {}
   }
 }

--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -1,42 +1,40 @@
-/*
-== Definition: postfix::hash
-
-Creates postfix hashed "map" files. It will create "${name}", and then build
-"${name}.db" using the "postmap" command. The map file can then be referred to
-using postfix::config.
-
-Parameters:
-- *name*: the name of the map file.
-- *ensure*: present/absent, defaults to present.
-- *source*: file source.
-
-Requires:
-- Class["postfix"]
-
-Example usage:
-
-  node "toto.example.com" {
-
-    include postfix
-
-    postfix::hash { "/etc/postfix/virtual":
-      ensure => present,
-    }
-    postfix::config { "virtual_alias_maps":
-      value => "hash:/etc/postfix/virtual"
-    }
-  }
-
-*/
-define postfix::hash ($ensure="present", $source = false) {
+#== Definition: postfix::hash
+#
+#Creates postfix hashed "map" files. It will create "${name}", and then build
+#"${name}.db" using the "postmap" command. The map file can then be referred to
+#using postfix::config.
+#
+#Parameters:
+#- *name*: the name of the map file.
+#- *ensure*: present/absent, defaults to present.
+#- *source*: file source.
+#
+#Requires:
+#- Class["postfix"]
+#
+#Example usage:
+#
+#  node "toto.example.com" {
+#
+#    include postfix
+#
+#    postfix::hash { "/etc/postfix/virtual":
+#      ensure => present,
+#    }
+#    postfix::config { "virtual_alias_maps":
+#      value => "hash:/etc/postfix/virtual"
+#    }
+#  }
+#
+define postfix::hash ($ensure='present', $source = false) {
 
   # selinux labels differ from one distribution to another
-  case $operatingsystem {
+  case $::operatingsystem {
 
     RedHat, CentOS: {
-      case $lsbmajdistrelease {
-        "4":     { $postfix_seltype = "etc_t" }
-        "5","6": { $postfix_seltype = "postfix_etc_t" }
+      case $::lsbmajdistrelease {
+        '4':     { $postfix_seltype = 'etc_t' }
+        '5','6': { $postfix_seltype = 'postfix_etc_t' }
         default: { $postfix_seltype = undef }
       }
     }
@@ -48,40 +46,40 @@ define postfix::hash ($ensure="present", $source = false) {
 
   case $source {
     false: {
-      file {"${name}":
+      file {$name:
         ensure  => $ensure,
-        mode    => 600,
+        mode    => '0600',
         owner   => root,
         group   => root,
         seltype => $postfix_seltype,
-        require => Package["postfix"],
+        require => Package['postfix'],
       }
     }
     default: {
-      file {"${name}":
+      file {$name:
         ensure  => $ensure,
-        mode    => 600,
+        mode    => '0600',
         owner   => root,
         group   => root,
         source  => $source,
         seltype => $postfix_seltype,
-        require => Package["postfix"],
+        require => Package['postfix'],
       }
     }
   }
 
   file {"${name}.db":
     ensure  => $ensure,
-    mode    => 600,
-    require => [File["${name}"], Exec["generate ${name}.db"]],
+    mode    => '0600',
+    require => [File[$name], Exec["generate ${name}.db"]],
     seltype => $postfix_seltype,
   }
 
   exec {"generate ${name}.db":
-    command => "postmap ${name}",
-    #creates => "${name}.db", # this prevents postmap from being run !
-    subscribe => File["${name}"],
+    command     => "postmap ${name}",
+    #creates    => "${name}.db", # this prevents postmap from being run !
+    subscribe   => File[$name],
     refreshonly => true,
-    require => Package["postfix"],
+    require     => Package['postfix'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,25 +5,26 @@
 # delivery and an SMTP server listening on the loopback interface.
 #
 # Parameters:
-# - *$postfix_smtp_listen*: address on which the smtp service will listen to. defaults to 127.0.0.1
-# - *$root_mail_recipient*: who will recieve root's emails. defaults to "nobody"
+# - *$postfix_smtp_listen*: address on which the smtp service will listen to.
+#      defaults to 127.0.0.1
+# - *$root_mail_recipient*: who will recieve root's emails. defaults to 'nobody'
 #
 # Example usage:
 #
-#   node "toto.example.com" {
-#     $postfix_smtp_listen = "192.168.1.10"
+#   node 'toto.example.com' {
+#     $postfix_smtp_listen = '192.168.1.10'
 #     include postfix
 #   }
 #
 class postfix {
 
   # selinux labels differ from one distribution to another
-  case $operatingsystem {
+  case $::operatingsystem {
 
     RedHat, CentOS: {
-      case $lsbmajdistrelease {
-        "4":     { $postfix_seltype = "etc_t" }
-        "5","6": { $postfix_seltype = "postfix_etc_t" }
+      case $::lsbmajdistrelease {
+        '4':     { $postfix_seltype = 'etc_t' }
+        '5','6': { $postfix_seltype = 'postfix_etc_t' }
         default: { $postfix_seltype = undef }
       }
     }
@@ -34,120 +35,124 @@ class postfix {
   }
 
   # Default value for various options
-  case $postfix_smtp_listen {
-    "": { $postfix_smtp_listen = "127.0.0.1" }
+  if $postfix_smtp_listen == '' {
+    $postfix_smtp_listen = '127.0.0.1'
   }
-  case $root_mail_recipient {
-    "":   { $root_mail_recipient = "nobody" }
+  if $root_mail_recipient == '' {
+    $root_mail_recipient = 'nobody'
   }
-  case $postfix_use_amavisd {
-    "": { $postfix_use_amavisd = "no" }
+  if $postfix_use_amavisd == '' {
+    $postfix_use_amavisd = 'no'
   }
-  case $postfix_use_dovecot_lda {
-    "": { $postfix_use_dovecot_lda = "no" }
+  if $postfix_use_dovecot_lda == '' {
+    $postfix_use_dovecot_lda = 'no'
   }
-  case $postfix_use_schleuder {
-    "": { $postfix_use_schleuder = "no" }
+  if $postfix_use_schleuder == '' {
+    $postfix_use_schleuder = 'no'
   }
-  case $postfix_use_sympa {
-    "": { $postfix_use_sympa = "no" }
+  if $postfix_use_sympa == '' {
+    $postfix_use_sympa = 'no'
   }
-  case $postfix_mail_user {
-    "": { $postfix_mail_user = "vmail" }
-  }
-
-
-  package { "postfix":
-    ensure => installed
+  if $postfix_mail_user == '' {
+    $postfix_mail_user = 'vmail'
   }
 
-  package { "mailx":
+  $mailx_package = $::lsbdistrelease ? {
+    'squeeze' => 'bsd-mailx',
+    'lucid'   => 'bsd-mailx',
+    default   => 'mailx',
+  }
+
+  $master_os_template = $::operatingsystem ? {
+    /RedHat|CentOS/          => 'postfix/master.cf.redhat.erb',
+    /Debian|Ubuntu|kFreeBSD/ => 'postfix/master.cf.debian.erb',
+  }
+
+  package { 'postfix':
     ensure => installed,
-    name   => $lsbdistcodename ? {
-      "squeeze" => "bsd-mailx",
-      "lucid"   => "bsd-mailx",
-      default   => "mailx",
-    },
   }
 
-  service { "postfix":
+  package { 'mailx':
+    ensure => installed,
+    name   => $mailx_package,
+  }
+
+  service { 'postfix':
     ensure    => running,
     enable    => true,
     hasstatus => true,
-    restart   => "/etc/init.d/postfix reload",
-    require   => Package["postfix"],
+    restart   => '/etc/init.d/postfix reload',
+    require   => Package['postfix'],
   }
 
-  file { "/etc/mailname":
+  file { '/etc/mailname':
     ensure  => present,
-    content => "${fqdn}\n",
+    content => "$::fqdn\n",
     seltype => $postfix_seltype,
   }
 
   # Aliases
-  file { "/etc/aliases":
-    ensure => present,
-    content => "# file managed by puppet\n",
+  file { '/etc/aliases':
+    ensure  => present,
+    content => '# file managed by puppet\n',
     replace => false,
     seltype => $postfix_seltype,
-    notify => Exec["newaliases"],
+    notify  => Exec['newaliases'],
   }
 
   # Aliases
-  exec { "newaliases":
-    command     => "/usr/bin/newaliases",
+  exec { 'newaliases':
+    command     => '/usr/bin/newaliases',
     refreshonly => true,
-    require     => Package["postfix"],
-    subscribe   => File["/etc/aliases"],
+    require     => Package['postfix'],
+    subscribe   => File['/etc/aliases'],
   }
 
   # Config files
-  file { "/etc/postfix/master.cf":
+  file { '/etc/postfix/master.cf':
     ensure  => present,
-    owner => "root",
-    group => "root",
-    mode => "0644",
-    content => $operatingsystem ? {
-      /RedHat|CentOS/ => template("postfix/master.cf.redhat.erb", "postfix/master.cf.common.erb"),
-      /Debian|Ubuntu|kFreeBSD/ => template("postfix/master.cf.debian.erb", "postfix/master.cf.common.erb"),
-    },
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => $master_os_template,
     seltype => $postfix_seltype,
-    notify  => Service["postfix"],
-    require => Package["postfix"],
+    notify  => Service['postfix'],
+    require => Package['postfix'],
   }
 
   # Config files
-  file { "/etc/postfix/main.cf":
+  file { '/etc/postfix/main.cf':
     ensure  => present,
-    owner => "root",
-    group => "root",
-    mode => "0644",
-    source  => "puppet:///modules/postfix/main.cf",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => 'puppet:///modules/postfix/main.cf',
     replace => false,
     seltype => $postfix_seltype,
-    notify  => Service["postfix"],
-    require => Package["postfix"],
+    notify  => Service['postfix'],
+    require => Package['postfix'],
   }
 
   # Default configuration parameters
   postfix::config {
-    "myorigin":   value => "${fqdn}";
-    "alias_maps": value => "hash:/etc/aliases";
-    "inet_interfaces": value => "all";
+    'myorigin':         value => $::fqdn;
+    'alias_maps':       value => 'hash:/etc/aliases';
+    'inet_interfaces':  value => 'all';
   }
 
-  case $operatingsystem {
+  case $::operatingsystem {
     RedHat, CentOS: {
       postfix::config {
-        "sendmail_path": value => "/usr/sbin/sendmail.postfix";
-        "newaliases_path": value => "/usr/bin/newaliases.postfix";
-        "mailq_path": value => "/usr/bin/mailq.postfix";
+        'sendmail_path':    value => '/usr/sbin/sendmail.postfix';
+        'newaliases_path':  value => '/usr/bin/newaliases.postfix';
+        'mailq_path':       value => '/usr/bin/mailq.postfix';
       }
     }
+    default: {}
   }
 
-  mailalias {"root":
+  mailalias {'root':
     recipient => $root_mail_recipient,
-    notify    => Exec["newaliases"],
+    notify    => Exec['newaliases'],
   }
 }

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -1,19 +1,19 @@
 class postfix::ldap inherits postfix {
-  Postfix::Config["alias_maps"] {
-    value => "'hash:/etc/aliases, ldap:/etc/postfix/ldap-aliases.cf'",
+  Postfix::Config['alias_maps'] {
+    value => '"hash:/etc/aliases, ldap:/etc/postfix/ldap-aliases.cf"',
   }
 
-  package {"postfix-ldap": }
+  package {'postfix-ldap': }
 
-  if ! $postfix_ldap_base {
+  if ! $::postfix_ldap_base {
     fail 'Missing $postfix_ldap_base !'
   }
 
-  file {"/etc/postfix/ldap-aliases.cf":
+  file {'/etc/postfix/ldap-aliases.cf':
     ensure  => present,
     owner   => root,
     group   => postfix,
-    content => template("postfix/postfix-ldap-aliases.cf.erb"),
-    require => Package["postfix-ldap"],
+    content => template('postfix/postfix-ldap-aliases.cf.erb'),
+    require => Package['postfix-ldap'],
   }
 }

--- a/manifests/mailman.pp
+++ b/manifests/mailman.pp
@@ -5,30 +5,33 @@
 # manager.
 #
 # Parameters:
-# - every global variable which works for class "postfix" will work here.
+# - every global variable which works for class 'postfix' will work here.
 #
 # Example usage:
 #
-#   node "toto.example.com" {
+#   node 'toto.example.com' {
 #     include mailman
 #     include postfix::mailman
 #   }
 #
 class postfix::mailman {
-  $postfix_smtp_listen = "0.0.0.0"
+  $postfix_smtp_listen = '0.0.0.0'
   include postfix
 
   postfix::config {
-    "virtual_alias_maps":                   value => "hash:/etc/postfix/virtual";
-    "transport_maps":                       value => "hash:/etc/postfix/transport";
-    "mailman_destination_recipient_limit":  value => "1";
+    'virtual_alias_maps':
+      value => 'hash:/etc/postfix/virtual';
+    'transport_maps':
+      value => 'hash:/etc/postfix/transport';
+    'mailman_destination_recipient_limit':
+      value => '1';
   }
 
-  postfix::hash { "/etc/postfix/virtual":
+  postfix::hash { '/etc/postfix/virtual':
     ensure => present,
   }
 
-  postfix::hash { "/etc/postfix/transport":
+  postfix::hash { '/etc/postfix/transport':
     ensure => present,
   }
 

--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -13,48 +13,50 @@
 # Parameters:
 # - *$postfix_relayhost*
 # - *$postfix_mydestination*
-# - every global variable which works for class "postfix" will work here.
+# - every global variable which works for class 'postfix' will work here.
 #
 # Example usage:
 #
-#   node "toto.example.com" {
-#     $postfix_relayhost = "mail.example.com"
-#     $postfix_smtp_listen = "0.0.0.0"
-#     $postfix_mydestination = "\$myorigin, myapp.example.com"
+#   node 'toto.example.com' {
+#     $postfix_relayhost = 'mail.example.com'
+#     $postfix_smtp_listen = '0.0.0.0'
+#     $postfix_mydestination = '\$myorigin, myapp.example.com'
 #
 #     include postfix::mta
 #
-#     postfix::transport { "myapp.example.com":
+#     postfix::transport { 'myapp.example.com':
 #       ensure => present,
-#       destination => "local:",
+#       destination => 'local:',
 #     }
 #   }
 #
 class postfix::mta {
 
-  case $postfix_relayhost {
-    "":   { fail("Required \$postfix_relayhost variable is not defined.") }
+  case $::postfix_relayhost {
+    '':      { fail('Required \$postfix_relayhost variable is not defined.') }
+    default: {}
   }
 
-  case $postfix_mydestination {
-    "": { $postfix_mydestination = "\$myorigin" }
+  case $::postfix_mydestination {
+    '':      { $postfix_mydestination = '\$myorigin' }
+    default: {}
   }
 
   include postfix
 
   postfix::config {
-    "mydestination":                        value => $postfix_mydestination;
-    "mynetworks":                           value => "127.0.0.0/8";
-    "relayhost":                            value => $postfix_relayhost;
-    "virtual_alias_maps":                   value => "hash:/etc/postfix/virtual";
-    "transport_maps":                       value => "hash:/etc/postfix/transport";
+    'mydestination':       value => $::postfix_mydestination;
+    'mynetworks':          value => '127.0.0.0/8';
+    'relayhost':           value => $::postfix_relayhost;
+    'virtual_alias_maps':  value => 'hash:/etc/postfix/virtual';
+    'transport_maps':      value => 'hash:/etc/postfix/transport';
   }
 
-  postfix::hash { "/etc/postfix/virtual":
+  postfix::hash { '/etc/postfix/virtual':
     ensure => present,
   }
 
-  postfix::hash { "/etc/postfix/transport":
+  postfix::hash { '/etc/postfix/transport':
     ensure => present,
   }
 

--- a/manifests/satellite.pp
+++ b/manifests/satellite.pp
@@ -9,14 +9,14 @@
 #
 # Parameters:
 # - *valid_fqdn*
-# - every global variable which works for class "postfix" will work here.
+# - every global variable which works for class 'postfix' will work here.
 #
 # Example usage:
 #
-#   node "toto.local.lan" {
-#     $postfix_relayhost = "mail.example.com"
-#     $valid_fqdn = "toto.example.com"
-#     $root_mail_recipient = "the.sysadmin@example.com"
+#   node 'toto.local.lan' {
+#     $postfix_relayhost = 'mail.example.com'
+#     $valid_fqdn = 'toto.example.com'
+#     $root_mail_recipient = 'the.sysadmin@example.com'
 #
 #     include postfix::satellite
 #   }
@@ -25,14 +25,14 @@ class postfix::satellite {
 
   # If $valid_fqdn exists, use it to override $fqdn
   case $valid_fqdn {
-    "":      { $valid_fqdn = $fqdn }
-    default: { $fqdn = "${valid_fqdn}" }
+    '':      { $valid_fqdn = $::fqdn }
+    default: { $fqdn = $valid_fqdn }
   }
 
   include postfix::mta
 
-  postfix::virtual {"@${valid_fqdn}":
+  postfix::virtual { "@${valid_fqdn}":
     ensure      => present,
-    destination => "root",
+    destination => 'root',
   }
 }

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -1,44 +1,42 @@
-/*
-== Definition: postfix::transport
-
-Manages content of the /etc/postfix/transport map.
-
-Parameters:
-- *name*: name of address postfix will lookup. See transport(5).
-- *destination*: where the emails will be delivered to. See transport(5).
-- *ensure*: present/absent, defaults to present.
-
-Requires:
-- Class["postfix"]
-- Postfix::Hash["/etc/postfix/transport"]
-- Postfix::Config["transport_maps"]
-- common::line (from module common)
-
-Example usage:
-
-  node "toto.example.com" {
-
-    include postfix
-
-    postfix::hash { "/etc/postfix/transport":
-      ensure => present,
-    }
-    postfix::config { "transport_maps":
-      value => "hash:/etc/postfix/transport"
-    }
-    postfix::transport { "mailman.example.com":
-      ensure      => present,
-      destination => "mailman",
-    }
-  }
-
-*/
-define postfix::transport ($ensure="present", $destination) {
+#== Definition: postfix::transport
+#
+#Manages content of the /etc/postfix/transport map.
+#
+#Parameters:
+#- *name*: name of address postfix will lookup. See transport(5).
+#- *destination*: where the emails will be delivered to. See transport(5).
+#- *ensure*: present/absent, defaults to present.
+#
+#Requires:
+#- Class["postfix"]
+#- Postfix::Hash["/etc/postfix/transport"]
+#- Postfix::Config["transport_maps"]
+#- common::line (from module common)
+#
+#Example usage:
+#
+#  node "toto.example.com" {
+#
+#    include postfix
+#
+#    postfix::hash { "/etc/postfix/transport":
+#      ensure => present,
+#    }
+#    postfix::config { "transport_maps":
+#      value => "hash:/etc/postfix/transport"
+#    }
+#    postfix::transport { "mailman.example.com":
+#      ensure      => present,
+#      destination => "mailman",
+#    }
+#  }
+#
+define postfix::transport ($destination, $ensure='present') {
   common::line {"${name} ${destination}":
-    ensure => $ensure,
-    file   => "/etc/postfix/transport",
-    line   => "${name} ${destination}",
-    notify => Exec["generate /etc/postfix/transport.db"],
-    require => Package["postfix"],
+    ensure  => $ensure,
+    file    => '/etc/postfix/transport',
+    line    => "${name} ${destination}",
+    notify  => Exec['generate /etc/postfix/transport.db'],
+    require => Package['postfix'],
   }
 }

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -1,44 +1,42 @@
-/*
-== Definition: postfix::virtual
-
-Manages content of the /etc/postfix/virtual map.
-
-Parameters:
-- *name*: name of address postfix will lookup. See virtual(8).
-- *destination*: where the emails will be delivered to. See virtual(8).
-- *ensure*: present/absent, defaults to present.
-
-Requires:
-- Class["postfix"]
-- Postfix::Hash["/etc/postfix/virtual"]
-- Postfix::Config["virtual_alias_maps"]
-- common::line (from module common)
-
-Example usage:
-
-  node "toto.example.com" {
-
-    include postfix
-
-    postfix::hash { "/etc/postfix/virtual":
-      ensure => present,
-    }
-    postfix::config { "virtual_alias_maps":
-      value => "hash:/etc/postfix/virtual"
-    }
-    postfix::virtual { "user@example.com":
-      ensure      => present,
-      destination => "root",
-    }
-  }
-
-*/
-define postfix::virtual ($ensure="present", $destination) {
+#== Definition: postfix::virtual
+#
+#Manages content of the /etc/postfix/virtual map.
+#
+#Parameters:
+#- *name*: name of address postfix will lookup. See virtual(8).
+#- *destination*: where the emails will be delivered to. See virtual(8).
+#- *ensure*: present/absent, defaults to present.
+#
+#Requires:
+#- Class["postfix"]
+#- Postfix::Hash["/etc/postfix/virtual"]
+#- Postfix::Config["virtual_alias_maps"]
+#- common::line (from module common)
+#
+#Example usage:
+#
+#  node "toto.example.com" {
+#
+#    include postfix
+#
+#    postfix::hash { "/etc/postfix/virtual":
+#      ensure => present,
+#    }
+#    postfix::config { "virtual_alias_maps":
+#      value => "hash:/etc/postfix/virtual"
+#    }
+#    postfix::virtual { "user@example.com":
+#      ensure      => present,
+#      destination => "root",
+#    }
+#  }
+#
+define postfix::virtual ($destination, $ensure = 'present') {
   common::line {"${name} ${destination}":
-    ensure => $ensure,
-    file   => "/etc/postfix/virtual",
-    line   => "${name} ${destination}",
-    notify => Exec["generate /etc/postfix/virtual.db"],
-    require => Package["postfix"],
+    ensure  => $ensure,
+    file    => '/etc/postfix/virtual',
+    line    => "${name} ${destination}",
+    notify  => Exec['generate /etc/postfix/virtual.db'],
+    require => Package['postfix'],
   }
 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,0 +1,1 @@
+include postfix


### PR DESCRIPTION
I thought I would contribute to make the module more compliant with the [Puppet Style Guide](http://docs.puppetlabs.com/guides/style_guide.html). I've tested with `puppet parser validate` and `puppet-lint`. 

I haven't tested the module to install Postfix with the changes yet though. But I think everything looks as alright and it **should** be working. 

Thanks for a great work on the module,
Cheers!
