### PR TITLE
correct mailx package for all ubuntu version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,10 @@ class postfix {
   $mailx_package = $::lsbdistcodename ? {
     'squeeze' => 'bsd-mailx',
     'lucid'   => 'bsd-mailx',
+    'maverick'=> 'bsd-mailx',
+    'natty'   => 'bsd-mailx',
+    'oneiric' => 'bsd-mailx',
+    'precise' => 'bsd-mailx',
     default   => 'mailx',
   }
 


### PR DESCRIPTION
still mailx is just a virtual package, provided by bsd-mailx (among others)
