### PR TITLE
Use single quotes to allow multi-values

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ define postfix::config ($value, $ensure = present) {
   case $ensure {
     present: {
       augeas { "set postfix '${name}' to '${value}'":
-        changes => "set $name $value",
+        changes => "set $name '$value'",
       }
     }
     absent: {


### PR DESCRIPTION
Use single quotes to allow values containing spaces and commas
