### PR TITLE
Unable to drop outbound external mail using transports

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -32,7 +32,7 @@
 #  }
 #
 define postfix::transport (
-  $destination,
+  $destination='',
   $nexthop='',
   $file='/etc/postfix/transport',
   $ensure='present'
@@ -41,21 +41,23 @@ define postfix::transport (
 
   case $ensure {
     'present': {
-      if ($nexthop) {
-        $changes = [
-          "set pattern[. = '${name}'] '${name}'",
-          "set pattern[. = '${name}']/transport '${destination}'",
-          # TODO: support nexthop
-          "set pattern[. = '${name}']/nexthop '${nexthop}'",
-        ]
+      if ($destination) {
+        $change_destination = "set pattern[. = '${name}']/transport '${destination}'"
       } else {
-        $changes = [
-          "set pattern[. = '${name}'] '${name}'",
-          "set pattern[. = '${name}']/transport '${destination}'",
-          # TODO: support nexthop
-          "clear pattern[. = '${name}']/nexthop",
-        ]
+        $change_destination = "clear pattern[. = '${name}']/transport"
       }
+
+      if ($nexthop) {
+        $change_nexthop = "set pattern[. = '${name}']/nexthop '${nexthop}'"
+      } else {
+        $change_nexthop = "clear pattern[. = '${name}']/nexthop"
+      }
+
+      $changes = [
+        "set pattern[. = '${name}'] '${name}'",
+        $change_destination,
+        $change_nexthop,
+      ]
     }
 
     'absent': {


### PR DESCRIPTION
I've tried to follow http://dannyman.toldme.com/2008/09/15/howto-postfix-deliver-external-devnull/ with the following:

```
postfix::transport { 'example.org':
  ensure      => present,
  destination => '',
}
postfix::transport { '.example.org':
  ensure      => absent,
  destination => '',
}
postfix::transport { '*':
  ensure      => present,
  destination => 'discard',
}
```

But augeas fails with

```
err: /Stage[main]/Development::Mail/Postfix::Transport[example.org]/Augeas[Postfix transport - example.org]: Could not evaluate: Save failed with return code false
err: /Stage[main]/Development::Mail/Postfix::Transport[.example.org]/Augeas[Postfix transport - .example.org]: Could not evaluate: Save failed with return code false
```
