### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class postfix {
     file { '/etc/aliases':
       ensure  => present,
       source  => $arg,
-      replace => false,
+      replace => true,
       seltype => $postfix_seltype,
       notify  => Exec['newaliases'],
     }


### PR DESCRIPTION
Change file {'/etc/aliases':...} to a defined resource so that different source aliases files may be used on different nodes.

In a site where there may be multiple Postfix instances, each needing its own /etc/aliases file, this change should allow that to work.
