### PR TITLE
Add template variables that were in debian master.cf but not redhat.

### DIFF
--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -7,10 +7,18 @@
 # service type  private unpriv  chroot  wakeup  maxproc command + args
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
-<% if @smtp_listen == 'all' -%>
+<% if @master_smtp -%>
+<%= @master_smtp %>
+<% elsif @smtp_listen == 'all' -%>
 smtp      inet  n       -       n       -       -       smtpd
 <% else -%>
 <%= @smtp_listen %>:smtp      inet  n       -       n       -       -       smtpd
+<% end -%>
+<% if @master_submission -%>
+<%= @master_submission %>
+<% end -%>
+<% if @master_smtps -%>
+<%= @master_smtps %>
 <% end -%>
 #smtp      inet  n       -       n       -       -       smtpd
 #submission inet n       -       n       -       -       smtpd


### PR DESCRIPTION
(this is the updated pull request with the correct author email (previous one accidentally had my work one))

Several options in the master.cf.debian.erb weren't in master.cf.redhat.erb. This adds those. Wonder if the differences are minor enough to not even need separate templates? Looks like the redhat ones don't chroot although that chroot option could be another template variable.
