### PR TITLE
$mydestination should allow comma separated values

### DIFF
--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -31,7 +31,7 @@ class postfix::mta (
 
   validate_re($relayhost, '^\S+$',
               'Wrong value for $relayhost')
-  validate_re($mydestination, '^\S+$',
+  validate_re($mydestination, '^\S+(?:,\s*\S+)*$',
               'Wrong value for $mydestination')
   validate_re($mynetworks, '^\S+$',
               'Wrong value for $mynetworks')


### PR DESCRIPTION
According to the example given in manifests/mta.pp,
$mydestination should allow '$myorigin, myapp.example.com'.
However, the regular expression doesn't allow this value.
