### PR TITLE
Include dependency augeas

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -2,6 +2,8 @@
 #  This class provides the augeas lenses used by the postfix class
 #
 class postfix::augeas {
+  include ::augeas
+
   augeas::lens {'postfix_transport':
     ensure      => present,
     lens_source => 'puppet:///modules/postfix/lenses/postfix_transport.aug',


### PR DESCRIPTION
To make usage of this module easier, the module could include the module it depends on. This include shouldn't hurt anyone, but avoids polluting the node manifests with library includes.
