### PR TITLE
Fix $root_mail_recipient to allow arrays

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,7 +118,9 @@ class postfix (
   validate_string($mynetworks)
   validate_string($myorigin)
   validate_string($relayhost)
-  validate_string($root_mail_recipient)
+  if ! is_array($root_mail_recipient) {
+    validate_string($root_mail_recipient)
+  }
   validate_string($smtp_listen)
 
 


### PR DESCRIPTION
According to the [documentation of Mailalias](http://docs.puppetlabs.com/references/3.2.latest/type.html#mailalias), multiple
recipients should be specified as array, however, this
modules expects $root_mail_recipient to be a string.
