### PR TITLE
Added proper path for postmap command

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -66,6 +66,7 @@ define postfix::hash (
 
   exec {"generate ${name}.db":
     command     => "postmap ${name}",
+    path        => ["/usr/sbin", "/usr/bin", "/sbin", "/bin"],
     #creates    => "${name}.db", # this prevents postmap from being run !
     subscribe   => File[$name],
     refreshonly => true,


### PR DESCRIPTION
Otherwise it may fail with:

```
'postmap /etc/postfix/virtual' is not qualified and no path was specified. Please qualify the command or specify a path.
```
