### PR TITLE
Make notify dependency of Augeas["Postfix virtual - ${name}"] more variable

### DIFF
--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -71,6 +71,6 @@ define postfix::virtual (
       Package['postfix'],
       Augeas::Lens['postfix_virtual'],
       ],
-    notify  => Postfix::Hash['/etc/postfix/virtual'],
+    notify  => Postfix::Hash[$file],
   }
 }


### PR DESCRIPTION
Since the $file variable is used everywhere else, it should also be used in the notify dependency.
