### PR TITLE
Fixed Suse master_os_template parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,8 +32,7 @@ class postfix::params {
         fail "Unsupported OS '${::operatingsystem}'"
       }
 
-      $master_os_template = "${module_name}/master.cf.${::operatingsystem}
-                             ${::operatingsystemrelease}.erb"
+      $master_os_template = "${module_name}/master.cf.${::operatingsystem}${::operatingsystemrelease}.erb"
     }
 
     default: {


### PR DESCRIPTION
master_os_template parameter wasn't functional since it included to much whitespaces/new line.
