### PR TITLE
Set path variable for Exec["generate ${name}.db"]

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -65,6 +65,7 @@ define postfix::hash (
   }
 
   exec {"generate ${name}.db":
+    path        => '/usr/sbin',
     command     => "postmap ${name}",
     #creates    => "${name}.db", # this prevents postmap from being run !
     subscribe   => File[$name],


### PR DESCRIPTION
Since it produced an error, i set the path variable explicitly.
Checked for compatibility on Ubuntu 14.04, SLES SP2+3, RedHat 5.3
