### PR TITLE
qualify postmap command

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -65,7 +65,7 @@ define postfix::hash (
   }
 
   exec {"generate ${name}.db":
-    command     => "postmap ${name}",
+    command     => "/usr/sbin/postmap ${name}",
     #creates    => "${name}.db", # this prevents postmap from being run !
     subscribe   => File[$name],
     refreshonly => true,

--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -65,7 +65,8 @@ define postfix::hash (
   }
 
   exec {"generate ${name}.db":
-    command     => "/usr/sbin/postmap ${name}",
+    command     => "postmap ${name}",
+    path        => $::path,
     #creates    => "${name}.db", # this prevents postmap from being run !
     subscribe   => File[$name],
     refreshonly => true,

--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -31,8 +31,8 @@ define postfix::hash (
   include ::postfix::params
 
   validate_absolute_path($name)
-  validate_string($source)
-  validate_string($content)
+  if !is_string($source) and !is_array($source) { fail("value for source should be either String Type or Array type got ${source}") }
+  if !is_string($content) and !is_array($content) { fail("value for source should be either String Type or Array type got ${content}") }
   validate_string($ensure)
   validate_re($ensure, ['present', 'absent'],
     "\$ensure must be either 'present' or 'absent', got '${ensure}'")


### PR DESCRIPTION
after starting work on embedding this module i got an error from the transport and virtual files that were trying to be created:
rr: Failed to apply catalog: 'postmap /etc/postfix/transport' is not qualified and no path was specified. Please qualify the command or specify a path.

after researching in the exec resource type i found that it is always required to specify either a full path to the command or a 'path' attribute specifying a search path for the command.
see below:
https://docs.puppetlabs.com/references/latest/type.html#exec-attributes