### PR TITLE
Systemd restart support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,11 @@ class postfix::params {
         default => undef,
       }
 
+      $restart_cmd = $::operatingsystemmajrelease ? {
+        '7'     => '/bin/systemctl reload postfix',
+        default => '/etc/init.d/postfix reload',
+      }
+
       $mailx_package = 'mailx'
 
       $master_os_template = "${module_name}/master.cf.redhat.erb"
@@ -14,6 +19,8 @@ class postfix::params {
 
     'Debian': {
       $seltype = undef
+
+      $restart_cmd = '/etc/init.d/postfix reload'
 
       $mailx_package = $::lsbdistcodename ? {
         /sarge|etch|lenny|lucid/ => 'mailx',
@@ -25,6 +32,8 @@ class postfix::params {
 
     'Suse': {
       $seltype = undef
+
+      $restart_cmd = '/etc/init.d/postfix reload'
 
       $mailx_package = 'mailx'
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,6 @@ class postfix::service {
     ensure    => running,
     enable    => true,
     hasstatus => true,
-    restart   => '/etc/init.d/postfix reload',
+    restart   => $::postfix::params::restart_cmd,
   }
 }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -67,7 +67,7 @@ describe 'postfix' do
           :ensure    => 'running',
           :enable    => 'true',
           :hasstatus => 'true',
-          :restart   => '/etc/init.d/postfix reload'
+          :restart   => '/bin/systemctl reload postfix'
       ) }
     end
   end


### PR DESCRIPTION
on red hat and centos 7 the postfix daemon is managed via systemd.  This changes the restart command for the service to use the systemctl command when the system is running rhel/centos 7.