### PR TITLE
Prevent duplicate declarations of packages

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,12 +1,15 @@
 class postfix::packages {
   include ::postfix::params
 
-  package { 'postfix':
-    ensure => installed,
+  if ! defined(Package['postfix']) {
+    package { 'postfix':
+      ensure => installed,
+    }
   }
 
-  package { 'mailx':
-    ensure => installed,
-    name   => $postfix::params::mailx_package,
+  if ! defined(Package[$postfix::params::mailx_package]) {
+    package { $postfix::params::mailx_package:
+      ensure => installed,
+    }
   }
 }


### PR DESCRIPTION
If eg. mailx is included by another module this patch prevents puppet failing with: 

Error: Duplicate declaration: Package[mailx] is already declared; cannot redeclare at ...