### PR TITLE
Fix #90 by hard-restarting postfix on configuration changes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,8 @@ class postfix::params {
       }
 
       $restart_cmd = $::operatingsystemmajrelease ? {
-        '7'     => '/bin/systemctl reload postfix',
-        default => '/etc/init.d/postfix reload',
+        '7'     => '/bin/systemctl restart postfix',
+        default => '/etc/init.d/postfix restart',
       }
 
       $mailx_package = 'mailx'
@@ -20,7 +20,7 @@ class postfix::params {
     'Debian': {
       $seltype = undef
 
-      $restart_cmd = '/etc/init.d/postfix reload'
+      $restart_cmd = '/etc/init.d/postfix restart'
 
       $mailx_package = $::lsbdistcodename ? {
         /sarge|etch|lenny/ => 'mailx',
@@ -33,7 +33,7 @@ class postfix::params {
     'Suse': {
       $seltype = undef
 
-      $restart_cmd = '/etc/init.d/postfix reload'
+      $restart_cmd = '/etc/init.d/postfix restart'
 
       $mailx_package = 'mailx'
 

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,1 @@
+ubuntu-14.04-x86_64-vagrant.yml

--- a/spec/acceptance/postfix_spec.rb
+++ b/spec/acceptance/postfix_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper_acceptance'
+
+describe 'postfix class' do
+
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { 'postfix': }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('postfix') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('postfix') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+end

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -31,7 +31,7 @@ describe 'postfix' do
               :ensure    => 'running',
               :enable    => 'true',
               :hasstatus => 'true',
-              :restart   => '/etc/init.d/postfix reload'
+              :restart   => '/etc/init.d/postfix restart'
             ) }
         else
           it { is_expected.to contain_file('/etc/mailname').with_seltype('postfix_etc_t').with_content("foo.example.com\n") }
@@ -50,7 +50,7 @@ describe 'postfix' do
                 :ensure    => 'running',
                 :enable    => 'true',
                 :hasstatus => 'true',
-                :restart   => '/bin/systemctl reload postfix'
+                :restart   => '/bin/systemctl restart postfix'
               ) }
           else
             it {
@@ -58,7 +58,7 @@ describe 'postfix' do
                 :ensure    => 'running',
                 :enable    => 'true',
                 :hasstatus => 'true',
-                :restart   => '/etc/init.d/postfix reload'
+                :restart   => '/etc/init.d/postfix restart'
               ) }
           end
         end
@@ -124,7 +124,7 @@ describe 'postfix' do
                 :ensure    => 'running',
                 :enable    => 'true',
                 :hasstatus => 'true',
-                :restart   => '/etc/init.d/postfix reload'
+                :restart   => '/etc/init.d/postfix restart'
               ) }
           end
         else

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,31 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'postfix')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'camptocamp-augeas'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
This is probably the most straight-forward workaround for #90. If the postfix configuration changes, we will do a real  `restart` (meaning `stop` and `start`, in general) instead of doing `reload`, which was the old behaviour.

This also introduces two basic Beaker acceptance tests, to prove it is working. I have successfully tested them with the `ubuntu-14.04-x86_64-vagrant.yml` nodeset. I also noticed that the `centos-6-x86_64-vagrant.yml` seems to be broken (it fails already on in the preparational steps of the beaker run).