### PR TITLE
include ::augeas into ::postfix::augeas

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -3,6 +3,7 @@
 #
 class postfix::augeas {
 
+  require ::augeas
   $module_path = get_module_path($module_name)
   augeas::lens {'postfix_transport':
     ensure       => present,


### PR DESCRIPTION
use require instead of include to ensure right order.

fixes #93