### PR TITLE
Add support for SLES 12 and newest openSUSE releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,15 +33,15 @@ class postfix::params {
     'Suse': {
       $seltype = undef
 
-      $restart_cmd = '/etc/init.d/postfix reload'
-
       $mailx_package = 'mailx'
 
-      if $::operatingsystem != 'SLES' {
-        fail "Unsupported OS '${::operatingsystem}'"
+      if $::operatingsystemmajrelease == '11' {
+        $restart_cmd = '/etc/init.d/postfix reload'
+        $master_os_template = "${module_name}/master.cf.${::operatingsystem}${::operatingsystemrelease}.erb"
+      } else {
+        $restart_cmd = '/usr/bin/systemctl reload postfix'
+        $master_os_template = "${module_name}/master.cf.sles.erb"
       }
-
-      $master_os_template = "${module_name}/master.cf.${::operatingsystem}${::operatingsystemrelease}.erb"
     }
 
     default: {

--- a/templates/master.cf.sles.erb
+++ b/templates/master.cf.sles.erb
@@ -1,0 +1,178 @@
+# file managed by puppet
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master" or
+# on-line: http://www.postfix.org/master.5.html).
+#
+# Do not forget to execute "postfix reload" after editing this file.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (yes)   (never) (100)
+# ==========================================================================
+<% if @master_smtp -%>
+<%= @master_smtp %>
+<% elsif @smtp_listen == 'all' -%>
+smtp      inet  n       -       n       -       -       smtpd
+<% else -%>
+<%= @smtp_listen %>:smtp      inet  n       -       n       -       -       smtpd
+<% end -%>
+<% if @master_submission -%>
+<%= @master_submission %>
+<% end -%>
+<% if @master_smtps -%>
+<%= @master_smtps %>
+<% end -%>
+#amavis    unix  -       -       n       -       4       smtp
+#  -o smtp_data_done_timeout=1200
+#  -o smtp_send_xforward_command=yes
+#  -o disable_dns_lookups=yes
+#  -o max_use=20
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy
+#submission inet n       -       n       -       -       smtpd
+#   -o syslog_name=postfix/submission
+#   -o smtpd_tls_security_level=encrypt
+#   -o smtpd_sasl_auth_enable=yes
+#   -o smtpd_reject_unlisted_recipient=no
+#   -o smtpd_client_restrictions=$mua_client_restrictions
+#   -o smtpd_helo_restrictions=$mua_helo_restrictions
+#   -o smtpd_sender_restrictions=$mua_sender_restrictions
+#   -o smtpd_recipient_restrictions=
+#   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#   -o milter_macro_daemon_name=ORIGINATING
+#smtps     inet  n       -       n       -       -       smtpd
+#    -o syslog_name=postfix/smtps
+#    -o smtpd_tls_wrappermode=yes
+#    -o content_filter=smtp:[127.0.0.1]:10024
+#    -o smtpd_sasl_auth_enable=yes
+#    -o smtpd_reject_unlisted_recipient=no
+#    -o smtpd_client_restrictions=$mua_client_restrictions
+#    -o smtpd_helo_restrictions=$mua_helo_restrictions
+#    -o smtpd_sender_restrictions=$mua_sender_restrictions
+#    -o smtpd_recipient_restrictions=
+#    -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#    -o milter_macro_daemon_name=ORIGINATING
+#628       inet  n       -       n       -       -       qmqpd
+pickup    unix  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       n       -       -       smtp
+# When relaying mail as backup MX, disable fallback_relay to avoid MX loops
+relay     unix  -       -       n       -       -       smtp
+	-o fallback_relay=
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+#localhost:10025 inet   n       -       n       -       -       smtpd
+#  -o content_filter=
+#  -o smtpd_delay_reject=no
+#  -o smtpd_client_restrictions=permit_mynetworks,reject
+#  -o smtpd_helo_restrictions=
+#  -o smtpd_sender_restrictions=
+#  -o smtpd_recipient_restrictions=permit_mynetworks,reject
+#  -o smtpd_data_restrictions=reject_unauth_pipelining
+#  -o smtpd_end_of_data_restrictions=
+#  -o smtpd_restriction_classes=
+#  -o mynetworks=127.0.0.0/8
+#  -o smtpd_error_sleep_time=0
+#  -o smtpd_soft_error_limit=1001
+#  -o smtpd_hard_error_limit=1000
+#  -o smtpd_client_connection_count_limit=0
+#  -o smtpd_client_connection_rate_limit=0
+#  -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_address_mappings
+#  -o local_header_rewrite_clients=
+#  -o local_recipient_maps=
+#  -o relay_recipient_maps=
+scache    unix  -       -       n       -       1       scache
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=<%= @mail_user %> argv=/usr/local/bin/maildrop -d ${recipient}
+#
+# ====================================================================
+#
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
+# Cyrus 2.1.5 (Amos Gouaux)
+# Also specify in main.cf: cyrus_destination_recipient_limit=1
+#
+cyrus     unix  -       n       n       -       -       pipe
+  user=cyrus argv=/usr/lib/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+#
+# Old example of delivery via Cyrus.
+#
+old-cyrus unix  -       n       n       -       -       pipe
+  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# ====================================================================
+#
+# Other external delivery methods.
+#
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+#
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#
+scalemail-backend unix -       n       n       -       2       pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+#  ${nexthop} ${user} ${extension}
+#
+mailman   unix  -       n       n       -       -       pipe
+  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+  ${nexthop} ${user}
+#
+procmail  unix  -       n       n       -       -       pipe
+  flags=R user=nobody argv=/usr/bin/procmail -t -m /etc/procmailrc ${sender} ${recipient}
+#
+dovecot   unix  -       n       n       -       -       pipe
+  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+#


### PR DESCRIPTION
A diff between the master.cf that comes with the sles package and the changes I did:

```patch
--- sles_master.cf	2015-06-14 14:02:24.837255195 +0200
+++ templates/master.cf.sles.erb	2015-06-14 13:31:54.094174891 +0200
@@ -1,3 +1,4 @@
+# file managed by puppet
 #
 # Postfix master process configuration file.  For details on the format
 # of the file, see the master(5) manual page (command: "man 5 master" or
@@ -9,7 +10,19 @@
 # service type  private unpriv  chroot  wakeup  maxproc command + args
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
+<% if @master_smtp -%>
+<%= @master_smtp %>
+<% elsif @smtp_listen == 'all' -%>
 smtp      inet  n       -       n       -       -       smtpd
+<% else -%>
+<%= @smtp_listen %>:smtp      inet  n       -       n       -       -       smtpd
+<% end -%>
+<% if @master_submission -%>
+<%= @master_submission %>
+<% end -%>
+<% if @master_smtps -%>
+<%= @master_smtps %>
+<% end -%>
 #amavis    unix  -       -       n       -       4       smtp
 #  -o smtp_data_done_timeout=1200
 #  -o smtp_send_xforward_command=yes
@@ -57,7 +70,9 @@
 proxymap  unix  -       -       n       -       -       proxymap
 proxywrite unix -       -       n       -       1       proxymap
 smtp      unix  -       -       n       -       -       smtp
+# When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       n       -       -       smtp
+	-o fallback_relay=
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error
@@ -101,8 +116,8 @@
 # maildrop. See the Postfix MAILDROP_README file for details.
 # Also specify in main.cf: maildrop_destination_recipient_limit=1
 #
-#maildrop  unix  -       n       n       -       -       pipe
-#  flags=DRhu user=vmail argv=/usr/local/bin/maildrop -d ${recipient}
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=<%= @mail_user %> argv=/usr/local/bin/maildrop -d ${recipient}
 #
 # ====================================================================
 #
@@ -120,44 +135,44 @@
 # Cyrus 2.1.5 (Amos Gouaux)
 # Also specify in main.cf: cyrus_destination_recipient_limit=1
 #
-#cyrus     unix  -       n       n       -       -       pipe
-#  user=cyrus argv=/usr/lib/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+cyrus     unix  -       n       n       -       -       pipe
+  user=cyrus argv=/usr/lib/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
 #
 # ====================================================================
 #
 # Old example of delivery via Cyrus.
 #
-#old-cyrus unix  -       n       n       -       -       pipe
-#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+old-cyrus unix  -       n       n       -       -       pipe
+  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
 #
 # ====================================================================
 #
 # See the Postfix UUCP_README file for configuration details.
 #
-#uucp      unix  -       n       n       -       -       pipe
-#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
 #
 # ====================================================================
 #
 # Other external delivery methods.
 #
-#ifmail    unix  -       n       n       -       -       pipe
-#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
 #
-#bsmtp     unix  -       n       n       -       -       pipe
-#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
 #
-#scalemail-backend unix -       n       n       -       2       pipe
-#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+scalemail-backend unix -       n       n       -       2       pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
 #  ${nexthop} ${user} ${extension}
 #
-#mailman   unix  -       n       n       -       -       pipe
-#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
-#  ${nexthop} ${user}
+mailman   unix  -       n       n       -       -       pipe
+  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+  ${nexthop} ${user}
 #
-#procmail  unix  -       n       n       -       -       pipe
-#  flags=R user=nobody argv=/usr/bin/procmail -t -m /etc/procmailrc ${sender} ${recipient}
+procmail  unix  -       n       n       -       -       pipe
+  flags=R user=nobody argv=/usr/bin/procmail -t -m /etc/procmailrc ${sender} ${recipient}
 #
-#dovecot   unix  -       n       n       -       -       pipe
-#  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+dovecot   unix  -       n       n       -       -       pipe
+  flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
 #
```