### PR TITLE
Use RHEL SELinux type for /etc/aliases

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -32,7 +32,7 @@ class postfix::files {
     content => "# file managed by puppet\n",
     notify  => Exec['newaliases'],
     replace => false,
-    seltype => $postfix::params::seltype,
+    seltype => $postfix::params::aliasesseltype,
   }
 
   # Aliases

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,15 @@
 class postfix::params {
   case $::osfamily {
     'RedHat': {
+      $aliasesseltype = $::operatingsystemmajrelease ? {
+        '4'     => 'etc_t',
+        /5/     => 'postfix_etc_t',
+        /6|7/   => 'etc_aliases_t',
+        default => undef,
+      }
+
       $seltype = $::operatingsystemmajrelease ? {
-        '4'   => 'etc_t',
+        '4'     => 'etc_t',
         /5|6|7/ => 'postfix_etc_t',
         default => undef,
       }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -35,7 +35,6 @@ describe 'postfix' do
             ) }
         else
           it { is_expected.to contain_file('/etc/mailname').with_seltype('postfix_etc_t').with_content("foo.example.com\n") }
-          it { is_expected.to contain_file('/etc/aliases').with_seltype('postfix_etc_t').with_content("# file managed by puppet\n") }
           it { is_expected.to contain_file('/etc/postfix/master.cf').with_seltype('postfix_etc_t') }
           it { is_expected.to contain_file('/etc/postfix/main.cf').with_seltype('postfix_etc_t') }
 
@@ -45,6 +44,7 @@ describe 'postfix' do
 
           case facts[:operatingsystemmajrelease]
           when '7'
+            it { is_expected.to contain_file('/etc/aliases').with_seltype('etc_aliases_t').with_content("# file managed by puppet\n") }
             it {
               is_expected.to contain_service('postfix').with(
                 :ensure    => 'running',
@@ -52,7 +52,17 @@ describe 'postfix' do
                 :hasstatus => 'true',
                 :restart   => '/bin/systemctl reload postfix'
               ) }
+          when '6'
+            it { is_expected.to contain_file('/etc/aliases').with_seltype('etc_aliases_t').with_content("# file managed by puppet\n") }
+            it {
+              is_expected.to contain_service('postfix').with(
+                :ensure    => 'running',
+                :enable    => 'true',
+                :hasstatus => 'true',
+                :restart   => '/etc/init.d/postfix reload'
+              ) }
           else
+            it { is_expected.to contain_file('/etc/aliases').with_seltype('postfix_etc_t').with_content("# file managed by puppet\n") }
             it {
               is_expected.to contain_service('postfix').with(
                 :ensure    => 'running',


### PR DESCRIPTION
On RHEL 6&7, the SELinux type of /etc/aliases is etc_aliases_t.
The module set a postfix_etc_t. It works too, but, as discussed, it's better to keep that RedHat provides.

I keep a case with "/6|7/", just to update to the right type, without waiting for the next types restore. It's not required for a new system, and I don't mind if we just removed this case.