### PR TITLE
Fix file permissions in postfix::hash

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -60,7 +60,6 @@ define postfix::hash (
     content => $content,
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
     require => Package['postfix'],
   }
 


### PR DESCRIPTION
Should be `0600` as defined in the `File` defaults, because these files may contain sensitive data. Lines 61-62 could be removed as well, since it coincides with the declared `File` defaults.
