### PR TITLE
Request #104: allow arrays for `postfix::config` values.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,8 +33,12 @@ define postfix::config ($value = undef, $ensure = 'present') {
   validate_re($ensure, ['present', 'absent', 'blank'],
     "\$ensure must be either 'present', 'absent' or 'blank', got '${ensure}'")
   if ($ensure == 'present') {
-    validate_string($value)
-    validate_re($value, '^.+$',
+    $real_value = is_array($value) ? {
+      true    => join($value, ' ') ,
+      default => $value ,
+    }
+    validate_string($real_value)
+    validate_re($real_value, '^.+$',
       '$value can not be empty if ensure = present')
   }
 
@@ -44,7 +48,7 @@ define postfix::config ($value = undef, $ensure = 'present') {
 
   case $ensure {
     'present': {
-      $changes = "set ${name} '${value}'"
+      $changes = "set ${name} '${real_value}'"
     }
     'absent': {
       $changes = "rm ${name}"

--- a/spec/defines/postfix_config_spec.rb
+++ b/spec/defines/postfix_config_spec.rb
@@ -23,12 +23,12 @@ describe 'postfix::config' do
 
       context 'when passing wrong type for value' do
         let (:params) { {
-          :value => ['bar'],
+          :value => {'bar' => 'baz'},
         } }
         it 'should fail' do
           expect {
             is_expected.to contain_augeas("set postfix 'foo'")
-          }.to raise_error(Puppet::Error, /\["bar"\] is not a string/)
+          }.to raise_error(Puppet::Error, /\{"bar"=>"baz"\} is not a string/)
         end
       end
 
@@ -92,6 +92,19 @@ describe 'postfix::config' do
           :incl    => '/etc/postfix/main.cf',
           :lens    => 'Postfix_Main.lns',
           :changes => "clear foo"
+        ) }
+      end
+
+      context 'when assigning an array' do
+        let (:params) { {
+          :value  => ['bar', 'baz'],
+          :ensure => 'present',
+        } }
+
+        it { is_expected.to contain_augeas("manage postfix 'foo'").with(
+          :incl    => '/etc/postfix/main.cf',
+          :lens    => 'Postfix_Main.lns',
+          :changes => "set foo 'bar baz'"
         ) }
       end
     end


### PR DESCRIPTION
Also update the spec file for postfix::config to test for arrays.
