### PR TITLE
Add mastercf_tail option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,9 @@
 #
 # [*mailx_ensure*]        - (string) The ensure value of the mailx package
 #
+# [*mastercf_tail*]       - (string) Add any additional content to the end of
+#                           master.cf
+#
 # === Examples
 #
 #   class { 'postfix':
@@ -98,6 +101,7 @@ class postfix (
   $use_sympa           = false,         # postfix_use_sympa
   $postfix_ensure      = 'present',
   $mailx_ensure        = 'present',
+  $mastercf_tail       = undef,
 ) inherits postfix::params {
 
 
@@ -128,6 +132,7 @@ class postfix (
     validate_string($root_mail_recipient)
   }
   validate_string($smtp_listen)
+  validate_string($mastercf_tail)
 
 
 

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -289,8 +289,21 @@ describe 'postfix' do
               is_expected.to contain_file('/etc/postfix/master.cf').with_content(/sympa/)
             end
           end
+          context 'when specifying mastercf_tail' do
+            let (:params) { {
+              :mastercf_tail         => "slow      unix  -       -       n       -       1       smtp
+    -o smtp_destination_concurrency_limit=1",
+            } }
+            it 'should update master.cf with the specified content' do
+              is_expected.to contain_file('/etc/postfix/master.cf').with_seltype('postfix_etc_t').with_content(
+                /slow      unix  -       -       n       -       1       smtp/).with_content(
+                  /^smtp.*\n.*smtp_destination_concurrency_limit=1/
+                )
+            end
+          end
         end
       end
     end
   end
 end
+

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -31,3 +31,7 @@ sympa        unix  -       n       n       -       -       pipe
 sympabounce  unix  -       n       n       -       -       pipe
   flags=R user=sympa argv=/usr/lib/sympa/bin/bouncequeue ${user}
 <% end -%>
+
+<% if @mastercf_tail -%>
+<%= @mastercf_tail %>
+<%- end -%>


### PR DESCRIPTION
This option lets you append anything to the end of your master.cf. This
is particularly useful if you have some custom transports, or other
configurations that you need to make that aren't part of the module, and
don't make sense to add to the module because they are too site-specific.
