### PR TITLE
Add virtual and transport regexp examples

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -26,12 +26,19 @@
 #       ensure => present,
 #     }
 #     postfix::config { 'transport_maps':
-#       value => 'hash:/etc/postfix/transport',
+#       value => 'hash:/etc/postfix/transport, regexp:/etc/postfix/transport_regexp',
 #     }
-#     postfix::transport { 'mailman.example.com':
-#       ensure      => present,
-#       destination => 'mailman',
+#     postfix::transport {
+#       'mailman.example.com':
+#          ensure      => present,
+#          destination => 'mailman';
+#       'slow_transport':
+#          ensure      => present,
+#          nexthop     => '/^user-.*@mydomain\.com/'
+#          file        => '/etc/postfix/transport_regexp',
+#          destination => 'slow'
 #     }
+#     
 #   }
 #
 define postfix::transport (

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -26,14 +26,19 @@
 #       ensure => present,
 #     }
 #     postfix::config { "virtual_alias_maps":
-#       value => "hash:/etc/postfix/virtual"
+#       value => "hash:/etc/postfix/virtual, regexp:/etc/postfix/virtual_regexp"
 #     }
 #     postfix::virtual { "user@example.com":
 #       ensure      => present,
 #       destination => "root",
 #     }
+#     postfix::virtual { "/.+@.+/"
+#       ensure      => present,
+#       file        => '/etc/postfix/virtual_regexp',
+#       destination => 'root',
+#     }
 #   }
-#
+
 define postfix::virtual (
   $destination,
   $file='/etc/postfix/virtual',


### PR DESCRIPTION
In my version of this module I had a virtual_regexp and a transport_regexp class, so I started to port those over to your module so I could submit a pull request, but I realized that the way its done here these can be handled with the regular virtual and transport classes with the right configuration. So instead of porting that unnecessary code, I just enhanced the examples in  your classes to show how you can have this functionality.
