### PR TITLE
Adds support for more than one destination in virtuals

### DIFF
--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -45,14 +45,15 @@ define postfix::virtual (
   validate_string($file)
   validate_absolute_path($file)
   validate_string($ensure)
+  
+  # Make destination into an array so we 
+  # can iterate
+  $_destinations = split($destination, ',')
+  $destinations = strip($_destinations)
 
   case $ensure {
     'present': {
-      $changes = [
-        "set pattern[. = '${name}'] '${name}'",
-        # TODO: support more than one destination
-        "set pattern[. = '${name}']/destination '${destination}'",
-      ]
+      $changes = template('postfix/virtual.dest.erb')
     }
 
     'absent': {

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -97,7 +97,8 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/etc/postfix/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => template('postfix/virtual.dest.erb'),
+          :changes => template('postfix/virtual.dest.erb')
+          )
         }
       end
 
@@ -112,7 +113,8 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/tmp/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => template('postfix/virtual.dest.erb'),
+          :changes => template('postfix/virtual.dest.erb')
+        )
         }
       end
 

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -97,7 +97,7 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/etc/postfix/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => template('postfix/virtual.dest.erb')
+          :changes => 'template(\'postfix/virtual.dest.erb\')',
           )
         }
       end
@@ -113,7 +113,7 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/tmp/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => template('postfix/virtual.dest.erb')
+          :changes => 'template(\'postfix/virtual.dest.erb\')',
         )
         }
       end

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -97,8 +97,14 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/etc/postfix/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => 'template(\'postfix/virtual.dest.erb\')',
-          )
+          :changes => [
+            "rm pattern[. = 'foo']/destination[.]
+set pattern[. = 'foo'] 'foo'
+        
+                
+    set pattern[. = 'foo']/destination[001] 'bar'
+    ",
+          ])
         }
       end
 
@@ -113,8 +119,14 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/tmp/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => 'template(\'postfix/virtual.dest.erb\')',
-        )
+          :changes => [
+            "rm pattern[. = 'foo']/destination[.]
+set pattern[. = 'foo'] 'foo'
+        
+                
+    set pattern[. = 'foo']/destination[001] 'bar'
+    ",
+          ])
         }
       end
 

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -97,10 +97,7 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/etc/postfix/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => [
-            "set pattern[. = 'foo'] 'foo'",
-            "set pattern[. = 'foo']/destination 'bar'",
-          ])
+          :changes => template('postfix/virtual.dest.erb'),
         }
       end
 
@@ -115,10 +112,7 @@ describe 'postfix::virtual' do
         it { is_expected.to contain_augeas('Postfix virtual - foo').with(
           :incl    => '/tmp/virtual',
           :lens    => 'Postfix_Virtual.lns',
-          :changes => [
-            "set pattern[. = 'foo'] 'foo'",
-            "set pattern[. = 'foo']/destination 'bar'",
-          ])
+          :changes => template('postfix/virtual.dest.erb'),
         }
       end
 

--- a/templates/virtual.dest.erb
+++ b/templates/virtual.dest.erb
@@ -1,0 +1,10 @@
+<%# The dot [.] will blow away all destinations not listed in the loop-%>
+rm pattern[. = '<%= @name %>']/destination[.]
+set pattern[. = '<%= @name %>'] '<%= @name %>'
+<% if @destinations and not @destinations.empty? -%>
+    <% i = 0 -%>    
+    <% @destinations.each do |dest| -%>
+        <% i += 1 -%>    
+    set pattern[. = '<%= @name %>']/destination[<%= sprintf("%03d", i) -%>] '<%= dest %>'
+    <% end -%>
+<% end -%>


### PR DESCRIPTION
Adds support for more than one destination in the virtual map.  This also will now remove entries that are not listed for a given map.

Big credit goes to @champain for the main logic with using the template :+1: 
