### PR TITLE
Add manage_root_alias parameter

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -9,6 +9,7 @@ class postfix::files {
   $master_smtps        = $postfix::master_smtps
   $master_submission   = $postfix::master_submission
   $myorigin            = $postfix::myorigin
+  $manage_root_alias   = $postfix::manage_root_alias
   $root_mail_recipient = $postfix::root_mail_recipient
   $smtp_listen         = $postfix::_smtp_listen
   $use_amavisd         = $postfix::use_amavisd
@@ -90,8 +91,11 @@ class postfix::files {
     default: {}
   }
 
-  mailalias {'root':
-    recipient => $root_mail_recipient,
-    notify    => Exec['newaliases'],
+  if $manage_root_alias {
+    mailalias {'root':
+      recipient => $root_mail_recipient,
+      notify    => Exec['newaliases'],
+    }
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,7 @@ class postfix (
   $mynetworks          = '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128', # postfix_mynetworks
   $myorigin            = $::fqdn,
   $relayhost           = undef,         # postfix_relayhost
+  $manage_root_alias   = true,
   $root_mail_recipient = 'nobody',      # root_mail_recipient
   $satellite           = false,
   $smtp_listen         = '127.0.0.1',   # postfix_smtp_listen
@@ -104,6 +105,7 @@ class postfix (
   validate_bool($ldap)
   validate_bool($mailman)
   validate_bool($mta)
+  validate_bool($manage_root_alias)
   validate_bool($satellite)
   validate_bool($use_amavisd)
   validate_bool($use_dovecot_lda)

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -289,6 +289,12 @@ describe 'postfix' do
               is_expected.to contain_file('/etc/postfix/master.cf').with_content(/sympa/)
             end
           end
+          context 'when manage_root_alias is false' do
+            let(:params) { { :manage_root_alias => false } }
+            it 'should not manage root mailalias' do
+              is_expected.not_to contain_mailalias('root')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Add manage_root_alias parameter to disable management of root's mailalias resource

I use a module that specifically manages the root user, and part of that's modules responsibility is root's mailalias.