### PR TITLE
Fix virtual.db and transport.db creation

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -70,6 +70,12 @@ define postfix::hash (
   }
 
   exec {"generate ${name}.db":
+    command => "postmap ${name}",
+    path    => $::path,
+    creates => "${name}.db", # this prevents postmap from being run !
+    require => File[$name],
+  }
+  exec {"regenerate ${name}.db":
     command     => "postmap ${name}",
     path        => $::path,
     #creates    => "${name}.db", # this prevents postmap from being run !

--- a/spec/defines/postfix_hash_spec.rb
+++ b/spec/defines/postfix_hash_spec.rb
@@ -69,6 +69,7 @@ describe 'postfix::hash' do
         }
         it { is_expected.to contain_file('/tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
+        it { is_expected.to contain_exec('regenerate /tmp/foo.db') }
       end
 
       context 'when passing content' do
@@ -83,6 +84,7 @@ describe 'postfix::hash' do
         }
         it { is_expected.to contain_file('/tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
+        it { is_expected.to contain_exec('regenerate /tmp/foo.db') }
       end
 
       context 'when not passing source or content' do
@@ -92,6 +94,7 @@ describe 'postfix::hash' do
         }
         it { is_expected.to contain_file('/tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
+        it { is_expected.to contain_exec('regenerate /tmp/foo.db') }
       end
 
       context 'when ensuring absence' do
@@ -102,6 +105,7 @@ describe 'postfix::hash' do
         it { is_expected.to contain_file('/tmp/foo').with_ensure('absent') }
         it { is_expected.to contain_file('/tmp/foo.db').with_ensure('absent') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
+        it { is_expected.to contain_exec('regenerate /tmp/foo.db') }
       end
     end
   end


### PR DESCRIPTION
Seems /etc/postfix/virtual and /etc/postfix/transport on a fresh install don't trigger a refresh of the postmap exec, so the File resource for the db file ends up creating a 0 byte file.  

May address #130