### PR TITLE
error when mailx package already defined

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -5,8 +5,11 @@ class postfix::packages {
     ensure => $postfix::postfix_ensure,
   }
 
-  package { 'mailx':
-    ensure => $postfix::mailx_ensure,
-    name   => $postfix::params::mailx_package,
+  if ! defined(Package['mailx']) {
+    package { 'mailx':
+      ensure => $postfix::mailx_ensure,
+      name   => $postfix::params::mailx_package,
+    }
   }
+
 }


### PR DESCRIPTION
I had an issue where even when invoking with
`  class { 'postfix':
    mailx_ensure => False
  }`
I got the error:
`Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Package[mailx] is already declared in file /etc/puppet/modules/base/manifests/install.pp:36; cannot redeclare at /etc/puppet/modules/postfix/manifests/packages.pp:11 on node xxxx
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
`
Didn't seem to work to just wrap in a
`if $postfix::mailx_ensure {`
so this seems to be the easiest way to work around a situation where the mailx package is already defined (I tried using ensure_packages() instead in the place where we define it, but that didn't work either).