### PR TITLE
Add $manage_mailx boolean to control whether mailx is managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ A Boolean defining whether the puppet module should replace the configuration fi
 
 Default: true.
 
+##### `manage_mailx`
+
+A Boolean defining whether the puppet module should manage the mailx package. See also $mailx_ensure.
+
+Default: true.
+
 ##### `mastercf_source`
 A string defining the location of a skeleton master.cf file to be used.  
 Default: Undefined.  

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@
 #
 # [*manage_conffiles*]    - (boolean) Whether config files are to be replaced
 #
+# [*manage_mailx*]        - (boolean) Whether to manage mailx package.
+#
 # [*mastercf_source*]     - (string)
 #
 # [*master_smtp*]         - (string)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,7 @@ class postfix (
   $mailman             = false,
   $maincf_source       = "puppet:///modules/${module_name}/main.cf",
   $manage_conffiles    = true,
+  $manage_mailx        = true,
   $mastercf_source     = undef,
   $master_smtp         = undef,         # postfix_master_smtp
   $master_smtps        = undef,         # postfix_master_smtps
@@ -106,6 +107,7 @@ class postfix (
   validate_bool($mailman)
   validate_bool($mta)
   validate_bool($manage_root_alias)
+  validate_bool($manage_mailx)
   validate_bool($satellite)
   validate_bool($use_amavisd)
   validate_bool($use_dovecot_lda)

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -5,7 +5,7 @@ class postfix::packages {
     ensure => $postfix::postfix_ensure,
   }
 
-  if ($manage_mailx) {
+  if ($postfix::manage_mailx) {
     package { 'mailx':
       ensure => $postfix::mailx_ensure,
       name   => $postfix::params::mailx_package,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -5,8 +5,10 @@ class postfix::packages {
     ensure => $postfix::postfix_ensure,
   }
 
-  package { 'mailx':
-    ensure => $postfix::mailx_ensure,
-    name   => $postfix::params::mailx_package,
+  if ($manage_mailx) {
+    package { 'mailx':
+      ensure => $postfix::mailx_ensure,
+      name   => $postfix::params::mailx_package,
+    }
   }
 }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -295,6 +295,12 @@ describe 'postfix' do
               is_expected.not_to contain_mailalias('root')
             end
           end
+          context 'when manage_mailx is false' do
+            let(:params) { { :manage_mailx => false } }
+            it 'should not have mailx package' do
+              is_expected.not_to contain_package('mailx')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
This supercedes #141.

I wonder if $ensure_mailx and $manage_mailx are a little redundant, though obviously ensure absent is slightly different from not managing it at all.

I did add a unit test, but got some Hiera errors when trying to run the spec tests locally (would be great if someone could fix whatever is causing the Travis CI tests to fail, as it seems to be happening for all PRs; some more docs about what is needed to run tests locally would also be helpful)