### PR TITLE
Specify path for Postfix map

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -52,6 +52,7 @@ define postfix::hash (
     source  => $source,
     content => $content,
     type    => 'hash',
+    path    => $name
   }
 
   Class['postfix'] -> Postfix::Hash[$title]


### PR DESCRIPTION
This patch fixes errors similar to the following:

No such file or directory @ rb_sysopen - /etc/postfix/etc/postfix/virtual

The reason is that postfix::map takes $name path of the file only and postfix::hash gets the $name as the full path. 
