### PR TITLE
Fix the path of the map database

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -83,7 +83,7 @@ define postfix::map (
   }
 
   exec {"generate ${name}.db":
-    command     => "postmap ${name}",
+    command     => "postmap ${path}",
     path        => $::path,
     #creates    => "${name}.db", # this prevents postmap from being run !
     refreshonly => true,


### PR DESCRIPTION
The postmap command needs the complete path of the database. In the exec the `$name` was used, while it needs `$path`.
