### PR TITLE
Allow setting config options as class arguments

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class postfix (
   $use_sympa           = false,         # postfix_use_sympa
   $postfix_ensure      = 'present',
   $mailx_ensure        = 'present',
+  $config_hash         = {},
 ) inherits postfix::params {
 
 
@@ -135,6 +136,7 @@ class postfix (
   }
   validate_string($smtp_listen)
 
+  validate_hash($config_hash)
 
 
   $_smtp_listen = $mailman ? {
@@ -173,5 +175,9 @@ class postfix (
 
   if $mailman {
     include ::postfix::mailman
+  }
+
+  if $config_hash {
+    ensure_resources('postfix::config', $config_hash)
   }
 }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -91,12 +91,14 @@ describe 'postfix' do
               :inet_interfaces     => 'localhost2',
               :master_smtp         => "smtp      inet  n       -       -       -       -       smtpd
     -o smtpd_client_restrictions=check_client_access,hash:/etc/postfix/access,reject",
-    :master_smtps        => 'smtps     inet  n       -       -       -       -       smtpd',
-    :master_submission   => 'submission inet n       -       -       -       -       smtpd',
+              :master_smtps        => 'smtps     inet  n       -       -       -       -       smtpd',
+              :master_submission   => 'submission inet n       -       -       -       -       smtpd',
+              :config_hash         => {'smtp_tls_mandatory_ciphers' => {'value' => 'high'}},
             } }
 
             it { is_expected.to contain_package('postfix') }
             it { is_expected.to contain_package('mailx') }
+            it { is_expected.to contain_postfix__config('smtp_tls_mandatory_ciphers').with_value('high') }
 
             it { is_expected.to contain_file('/etc/mailname').without('seltype').with_content("foo.example.com\n") }
             it { is_expected.to contain_file('/etc/aliases').without('seltype').with_content("# file managed by puppet\n") }


### PR DESCRIPTION
This will allow me to pass in hash for setting masquerade_domains (or any other parameter) that would could be set via explicit resource calls.

This mainly cleans up the workflow with an ENC like Foreman.
