### PR TITLE
postfix::map: don't exec postmap when ensure=absent

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -52,6 +52,7 @@ define postfix::hash (
     source  => $source,
     content => $content,
     type    => 'hash',
+    path    => $name,
   }
 
   Class['postfix'] -> Postfix::Hash[$title]

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -82,8 +82,14 @@ define postfix::map (
     }
   }
 
+  $generate_cmd = $ensure ? {
+    'absent'  => "rm ${name}.db",
+    'present' => "postmap ${name}",
+    default   => "touch ${name}.db",
+  }
+
   exec {"generate ${name}.db":
-    command     => "postmap ${name}",
+    command     => $generate_cmd,
     path        => $::path,
     #creates    => "${name}.db", # this prevents postmap from being run !
     refreshonly => true,

--- a/spec/defines/postfix_map_spec.rb
+++ b/spec/defines/postfix_map_spec.rb
@@ -92,7 +92,10 @@ describe 'postfix::map' do
 
         it { is_expected.to contain_file('postfix map foo').with_ensure('absent') }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('absent') }
-        it { is_expected.to contain_exec('generate foo.db') }
+        it { is_expected.to contain_exec('generate foo.db').with(
+          :command => 'rm foo.db'
+        )
+        }
       end
 
       context 'when using pcre type' do


### PR DESCRIPTION
When ensure=absent, the postmap file is deleted. Attempting to run postmap on a non-existing file fails.
