### PR TITLE
Fix map calling in hash

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -52,6 +52,7 @@ define postfix::hash (
     source  => $source,
     content => $content,
     type    => 'hash',
+    path    => $name,
   }
 
   Class['postfix'] -> Postfix::Hash[$title]


### PR DESCRIPTION
map defines the default path by prepending '/etc/postfix/' to $name, so
this doesn't work when the name is already the absolute path. We need
to force the path passed to map.