### PR TITLE
master.cf template for SLES 11 SP4

### DIFF
--- a/templates/master.cf.SLES11.4.erb
+++ b/templates/master.cf.SLES11.4.erb
@@ -1,0 +1,82 @@
+#
+### This file is managed by Puppet, all edits will be lost on next Puppet run!
+#
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the Postfix master(5) manual page.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (yes)   (never) (100)
+# ==========================================================================
+<% if @smtp_listen == 'all' -%>
+smtp      inet  n       -       n       -       -       smtpd
+<% else -%>
+<%= @smtp_listen %>:smtp      inet  n       -       n       -       -       smtpd
+<% end -%>
+#submission inet n      -       n       -       -       smtpd
+#       -o smtpd_etrn_restrictions=reject
+#       -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+#smtps    inet  n       -       n       -       -       smtpd
+#  -o smtpd_tls_wrappermode=yes -o smtpd_sasl_auth_enable=yes
+#submission   inet    n       -       n       -       -       smtpd
+#  -o smtpd_etrn_restrictions=reject
+#  -o smtpd_enforce_tls=yes -o smtpd_sasl_auth_enable=yes
+#628      inet  n       -       n       -       -       qmqpd
+pickup    fifo  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      fifo  n       -       n       300     1       qmgr
+#qmgr     fifo  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+smtp      unix  -       -       n       -       -       smtp
+# When relaying mail as backup MX, disable smtp_fallback_relay to avoid MX loops
+relay     unix  -       -       n       -       -       smtp
+        -o smtp_fallback_relay=
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+#localhost:10025 inet   n       -       n       -       -       smtpd -o content_filter=
+scache    unix  -       -       n       -       1       scache
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=vmail argv=/usr/local/bin/maildrop -d ${recipient}
+cyrus     unix  -       n       n       -       -       pipe
+  user=cyrus argv=/usr/lib/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=foo argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+procmail  unix  -       n       n       -       -       pipe
+  flags=R user=nobody argv=/usr/bin/procmail -t -m /etc/procmailrc ${sender} ${recipient}
+retry     unix  -       -       n       -       -       error
+proxywrite unix -       -       n       -       1       proxymap
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy


### PR DESCRIPTION
The module fails on SLES 11 SP4 , as the template for this OS release is missing. The module only verifies the operatingsystem and if is SLES, it assigns the corresponding template, based on the system release. 