### PR TITLE
ship chrooted master.cf option to maintain compatibility with postfix3/xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ A string defining the location of the alias map file.
 Default: 'hash:/etc/aliases'.  
 Example: 'hash:/etc/other_aliases'.
 
+##### `chroot_daemons`
+
+A Boolean defining whether to chroot Postfix daemon processes as reccomended in Postfix3.
+Currently only applicable to the Postfix3 distributed by Ubuntu 16.04.
+
 ##### `inet_interfaces`
 
 A string defining the network interfaces that Postfix will listen on.  

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -2,6 +2,7 @@ class postfix::files {
   include ::postfix::params
 
   $alias_maps          = $postfix::all_alias_maps
+  $chroot_daemons      = $postfix::chroot_daemons
   $inet_interfaces     = $postfix::inet_interfaces
   $mail_user           = $postfix::mail_user
   $manage_conffiles    = $postfix::manage_conffiles

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,6 @@ class postfix (
   $mailx_ensure        = 'present',
 ) inherits postfix::params {
 
-  
   validate_bool($chroot_daemons)
   validate_bool($ldap)
   validate_bool($mailman)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 #
 # [*alias_maps*]          - (string)
 #
+# [*chroot_daemons*]      - (boolean) Whether to chroot daemons in as reccomended in postfix3 and above
+#
 # [*inet_interfaces*]     - (string)
 #
 # [*ldap*]                - (boolean) Whether to use LDAP
@@ -73,6 +75,7 @@
 #
 class postfix (
   $alias_maps          = 'hash:/etc/aliases',
+  $chroot_daemons      = false,
   $inet_interfaces     = 'all',
   $ldap                = false,
   $ldap_base           = undef,
@@ -104,7 +107,8 @@ class postfix (
   $mailx_ensure        = 'present',
 ) inherits postfix::params {
 
-
+  
+  validate_bool($chroot_daemons)
   validate_bool($ldap)
   validate_bool($mailman)
   validate_bool($mta)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,12 @@ class postfix::params {
         default            => 'bsd-mailx',
       }
 
-      $master_os_template = "${module_name}/master.cf.debian.erb"
+      if $::lsbdistcodename == 'xenial' and $chroot_daemons == 'true' {
+        $master_os_template = "${module_name}/master.cf.debian-chroot_daemons.erb"
+          }
+      else {
+        $master_os_template = "${module_name}/master.cf.debian.erb"
+          }
     }
 
     'Suse': {

--- a/templates/master.cf.debian-chroot_daemons.erb
+++ b/templates/master.cf.debian-chroot_daemons.erb
@@ -1,0 +1,88 @@
+# file managed by puppet
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master").
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (yes)   (never) (100)
+# ==========================================================================
+<% if @master_smtp -%>
+<%= @master_smtp %>
+<% elsif @smtp_listen == 'all' -%>
+smtp      inet  n       -       y       -       -       smtpd
+<% else -%>
+<%= @smtp_listen %>:smtp      inet  n       -       y       -       -       smtpd
+<% end -%>
+<% if @master_submission -%>
+<%= @master_submission %>
+<% end -%>
+<% if @master_smtps -%>
+<%= @master_smtps %>
+<% end -%>
+#submission inet n       -       y       -       -       smtpd
+#  -o smtpd_enforce_tls=yes
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+#smtps     inet  n       -       y       -       -       smtpd
+#  -o smtpd_tls_wrappermode=yes
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+#628      inet  n       -       -       -       -       qmqpd
+pickup    fifo  n       -       y       60      1       pickup
+cleanup   unix  n       -       y       -       0       cleanup
+qmgr      fifo  n       -       n       300     1       qmgr
+#qmgr     fifo  n       -       -       300     1       oqmgr
+tlsmgr    unix  -       -       y       1000?   1       tlsmgr
+rewrite   unix  -       -       y       -       -       trivial-rewrite
+bounce    unix  -       -       y       -       0       bounce
+defer     unix  -       -       y       -       0       bounce
+trace     unix  -       -       y       -       0       bounce
+verify    unix  -       -       y       -       1       verify
+flush     unix  n       -       y       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+smtp      unix  -       -       y       -       -       smtp
+# When relaying mail as backup MX, disable fallback_relay to avoid MX loops
+relay     unix  -       -       y       -       -       smtp
+	-o fallback_relay=
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       y       -       -       showq
+error     unix  -       -       y       -       -       error
+discard   unix  -       -       y       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       y       -       -       lmtp
+anvil     unix  -       -       y       -       1       anvil
+scache	  unix	-	-	y	-	1	scache
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+maildrop  unix  -       n       n       -       -       pipe
+  flags=DRhu user=<%= @mail_user %> argv=/usr/bin/maildrop -d ${recipient}
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+uucp      unix  -       n       n       -       -       pipe
+  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# Other external delivery methods.
+#
+ifmail    unix  -       n       n       -       -       pipe
+  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+bsmtp     unix  -       n       n       -       -       pipe
+  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
+scalemail-backend unix	-	n	n	-	2	pipe
+  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
+mailman   unix  -       n       n       -       -       pipe
+  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+  ${nexthop} ${user}


### PR DESCRIPTION
 - This ships a master.cf with various daemons chrooted (y)
 - This resolves the warnings generated by postfix when this module when used with xenial 16.04 
 - the boolean is false by default, turn it on with chroot_daemons => true when using xenial. 
 - Updated documentation to reflect change.

Thoughts - Theres a few different ways to accomodate the change in behaviour by postfix - I've picked the one that is simplest option for the module (and to avoid re-writing every master.cf template with fifteen or so chroot=y conditionals)