### PR TITLE
Include params rather than inherit them.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,7 +102,7 @@ class postfix (
   $use_sympa           = false,         # postfix_use_sympa
   $postfix_ensure      = 'present',
   $mailx_ensure        = 'present',
-) inherits postfix::params {
+) { include ::postfix::params
 
 
   validate_bool($ldap)


### PR DESCRIPTION
This will allow user-set variables to be passed to params, as the main class (init.pp) will be evaluated first.