### PR TITLE
Add master_entries parameter to postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ A string to define the submission line in the /etc/postfix/master.cf file.
 Default: Undefined.  
 Example: 'submission inet n       -       n       -       -       smtpd'.
 
+##### `master_entries`
+Array of strings containing additional entries for the /etc/postfix/master.cf file.
+Default: Undefined.
+Example: 'submission inet n       -       n       -       -       smtpd'.
+
 ##### `mta`
 A Boolean to define whether to configure Postfix as a mail transfer agent. This option is mutually exclusive with the satellite Boolean.  
 Default: False.

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -11,6 +11,7 @@ class postfix::files {
   $master_smtp         = $postfix::master_smtp
   $master_smtps        = $postfix::master_smtps
   $master_submission   = $postfix::master_submission
+  $master_entries      = $postfix::master_entries
   $myorigin            = $postfix::myorigin
   $manage_root_alias   = $postfix::manage_root_alias
   $root_mail_recipient = $postfix::root_mail_recipient

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 #
 # [*master_submission*]   - (string)
 #
+# [*master_entries*]      - (array of strings)
+#
 # [*mta*]                 - (boolean) Configure postfix minimally, as a simple MTA
 #
 # [*mydestination*]       - (string)
@@ -92,6 +94,7 @@ class postfix (
   Optional[String]                $master_smtp         = undef,         # postfix_master_smtp
   Optional[String]                $master_smtps        = undef,         # postfix_master_smtps
   Optional[String]                $master_submission   = undef,         # postfix_master_submission
+  Optional[Array[String]]         $master_entries      = undef,         # postfix_master_entries
   Boolean                         $mta                 = false,
   String                          $mydestination       = '$myorigin',   # postfix_mydestination
   String                          $mynetworks          = '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128', # postfix_mynetworks

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -31,3 +31,6 @@ sympa        unix  -       n       n       -       -       pipe
 sympabounce  unix  -       n       n       -       -       pipe
   flags=R user=sympa argv=/usr/lib/sympa/bin/bouncequeue ${user}
 <% end -%>
+<% if @master_entries %>
+<%= @master_entries.join("\n") %>
+<% end -%>


### PR DESCRIPTION
It is an optional array of strings containing addtional entries for the
master.cf file