### PR TITLE
Add inet_protocols option

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -3,6 +3,7 @@ class postfix::files {
 
   $alias_maps          = $postfix::all_alias_maps
   $inet_interfaces     = $postfix::inet_interfaces
+  $inet_protocols      = $postfix::inet_protocols
   $mail_user           = $postfix::mail_user
   $manage_conffiles    = $postfix::manage_conffiles
   $maincf_source       = $postfix::maincf_source
@@ -84,6 +85,7 @@ class postfix::files {
   ::postfix::config {
     'alias_maps':       value => $alias_maps;
     'inet_interfaces':  value => $inet_interfaces;
+    'inet_protocols':   value => $inet_protocols;
     'myorigin':         value => $myorigin;
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,8 @@
 #
 # [*inet_interfaces*]     - (string)
 #
+# [*inet_protocols*]      - (string)
+#
 # [*ldap*]                - (boolean) Whether to use LDAP
 #
 # [*ldap_base*]           - (string)
@@ -74,6 +76,7 @@
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
   String                          $inet_interfaces     = 'all',
+  String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,
   Optional[String]                $ldap_base           = undef,
   Optional[String]                $ldap_host           = undef,

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -18,6 +18,7 @@ describe 'postfix' do
         it { is_expected.to contain_postfix__config('myorigin').with_value('foo.example.com') }
         it { is_expected.to contain_postfix__config('alias_maps').with_value('hash:/etc/aliases') }
         it { is_expected.to contain_postfix__config('inet_interfaces').with_value('all') }
+        it { is_expected.to contain_postfix__config('inet_protocols').with_value('all') }
         it { is_expected.to contain_mailalias('root').with_recipient('nobody') }
 
         case facts[:osfamily]


### PR DESCRIPTION
Adds a parameter for inet_protocols with a default value of 'all' (the Postfix default.) 

The goal is to give the option of setting the appropriate value for clients where IPV6 is disabled. Postfix will not start with the default value if an IPV6 interface is not present.  