### PR TITLE
more than two amavis processes

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -2,6 +2,7 @@ class postfix::files {
   include ::postfix::params
 
   $alias_maps          = $postfix::all_alias_maps
+  $amavis_procs        = $postfix::amavis_procs
   $inet_interfaces     = $postfix::inet_interfaces
   $inet_protocols      = $postfix::inet_protocols
   $mail_user           = $postfix::mail_user

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,8 @@
 #
 # [*configs*]             - (hash)
 #
+# [*amavis_procs*]        - (string) Number of amavis scanners to spawn
+#
 # [*inet_interfaces*]     - (string)
 #
 # [*inet_protocols*]      - (string)
@@ -89,6 +91,7 @@
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
   Optional[Hash]                  $configs             = {},
+  String                          $amavis_procs        = '2',
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
   Optional[Hash]                  $configs             = {},
-  String                          $amavis_procs        = '2',
+  Integer                         $amavis_procs        = '2',
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 #
 # [*configs*]             - (hash)
 #
-# [*amavis_procs*]        - (string) Number of amavis scanners to spawn
+# [*amavis_procs*]        - (integer) Number of amavis scanners to spawn
 #
 # [*inet_interfaces*]     - (string)
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
   Optional[Hash]                  $configs             = {},
-  Integer                         $amavis_procs        = '2',
+  Integer                         $amavis_procs        = 2,
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -1,5 +1,5 @@
 <% if @use_amavisd %>
-amavis unix - - <%= @jail %> - 2 smtp
+amavis unix - - <%= @jail %> - <%= @amavis_procs %> smtp
         -o smtp_data_done_timeout=1200
         -o smtp_send_xforward_command=yes
 
@@ -15,7 +15,7 @@ amavis unix - - <%= @jail %> - 2 smtp
         -o mynetworks=127.0.0.0/8
         -o strict_rfc821_envelopes=yes
         -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks
-        -o smtpd_bind_address=127.0.0.1
+        -o smtp_bind_address=127.0.0.1
 <% end -%>
 <% if @use_dovecot_lda %>
 dovecot   unix  -       n       n       -       -       pipe

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -15,7 +15,7 @@ amavis unix - - <%= @jail %> - <%= @amavis_procs %> smtp
         -o mynetworks=127.0.0.0/8
         -o strict_rfc821_envelopes=yes
         -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks
-        -o smtp_bind_address=127.0.0.1
+        -o smtpd_bind_address=127.0.0.1
 <% end -%>
 <% if @use_dovecot_lda %>
 dovecot   unix  -       n       n       -       -       pipe


### PR DESCRIPTION
We found it necessary to have more running smtp processes that feed mail through amavis -- it helps process mail faster on servers with more resources, so I've put in a new variable that will set this.  I made the default to be '2', so it does not change anything for a default installation.

Also, 'smtpd_bind_address' is not a setting in Postfix, but 'smtp_bind_address' is.