### PR TITLE
Update postfix::virtual augeas lens to match upstream version

### DIFF
--- a/files/lenses/postfix_virtual.aug
+++ b/files/lenses/postfix_virtual.aug
@@ -29,10 +29,10 @@ let space_or_eol_re = /([ \t]*\n)?[ \t]+/
 
 (* View: space_or_eol *)
 let space_or_eol (sep:regexp) (default:string) =
-  del (space_or_eol_re? . sep . space_or_eol_re?) default 
+  del (space_or_eol_re? . sep . space_or_eol_re?) default
 
 (* View: word *)
-let word = store /[A-Za-z0-9@\*.+-]+/
+let word = store /[A-Za-z0-9@\*.+=_-]+/
 
 (* View: comma *)
 let comma = space_or_eol "," ", "

--- a/files/lenses/test_postfix_virtual.aug
+++ b/files/lenses/test_postfix_virtual.aug
@@ -10,7 +10,11 @@ let conf = "# a comment
 virtual-alias.domain     anything
 postmaster@virtual-alias.domain  postmaster
 user1@virtual-alias.domain       address1
-user2@virtual-alias.domain   
+user-1@virtual-alias.domain       address1
+user_2@virtual-alias.domain
+    address2,
+    address3
+user+test@virtual-alias.domain
     address2,
     address3
 root    robert.oot@domain.com
@@ -29,7 +33,14 @@ test Postfix_Virtual.lns get conf =
   { "pattern" = "user1@virtual-alias.domain"
     { "destination" = "address1" }
   }
-  { "pattern" = "user2@virtual-alias.domain"
+  { "pattern" = "user-1@virtual-alias.domain"
+    { "destination" = "address1" }
+  }
+  { "pattern" = "user_2@virtual-alias.domain"
+    { "destination" = "address2" }
+    { "destination" = "address3" }
+  }
+  { "pattern" = "user+test@virtual-alias.domain"
     { "destination" = "address2" }
     { "destination" = "address3" }
   }

--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -14,7 +14,7 @@ class postfix::augeas {
     ensure       => present,
     lens_content => file("${module_path}/files/lenses/postfix_virtual.aug"),
     test_content => file("${module_path}/files/lenses/test_postfix_virtual.aug"),
-    stock_since  => '1.0.0',
+    stock_since  => '1.7.0',
   }
   augeas::lens {'postfix_canonical':
     ensure       => present,


### PR DESCRIPTION
Fixes #176 

This basically syncs the internal lens with the version in upstream.
We are still on augeas 1.4.0 which doesn't have this code.
I have set the stock_version to 1.7.0 so this will be installed.