### PR TITLE
Add missing retry service

### DIFF
--- a/templates/master.cf.debian.erb
+++ b/templates/master.cf.debian.erb
@@ -48,6 +48,7 @@ relay     unix  -       -       -       -       -       smtp
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       -       -       -       showq
 error     unix  -       -       -       -       -       error
+retry     unix  -       -       -       -       -       error
 discard   unix  -       -       -       -       -       discard
 local     unix  -       n       n       -       -       local
 virtual   unix  -       n       n       -       -       virtual

--- a/templates/master.cf.redhat.erb
+++ b/templates/master.cf.redhat.erb
@@ -49,6 +49,7 @@ relay     unix  -       -       n       -       -       smtp
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error
+retry     unix  -       -       -       -       -       error
 discard   unix  -       -       n       -       -       discard
 local     unix  -       n       n       -       -       local
 virtual   unix  -       n       n       -       -       virtual


### PR DESCRIPTION
The retry service is required since postfix 2.4, its missing for redhat and debian.