### PR TITLE
Define master_content from outside of the module

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -8,6 +8,7 @@ class postfix::files {
   $manage_conffiles    = $postfix::manage_conffiles
   $maincf_source       = $postfix::maincf_source
   $mastercf_source     = $postfix::mastercf_source
+  $mastercf_content    = $postfix::mastercf_content
   $master_smtp         = $postfix::master_smtp
   $master_smtps        = $postfix::master_smtps
   $master_submission   = $postfix::master_submission
@@ -51,14 +52,15 @@ class postfix::files {
     subscribe   => File['/etc/aliases'],
   }
 
-  # Config files
+  # Config files - mastercf_source wins over mastercf_content
   if $mastercf_source {
     $mastercf_content = undef
-  } else {
-    $mastercf_content = template(
-        $postfix::params::master_os_template,
-        'postfix/master.cf.common.erb'
-      )
+  }
+  unless $mastercf_content {                      # if mastercf_content is not provided from outside of the modulle we use our templates
+      $mastercf_content = template(
+          $postfix::params::master_os_template,
+          'postfix/master.cf.common.erb'
+        )
   }
 
   file { '/etc/postfix/master.cf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #
 # [*mastercf_source*]     - (string)
 #
+# [*mastercf_content*]    - (string)
+#
 # [*master_smtp*]         - (string)
 #
 # [*master_smtps*]        - (string)
@@ -86,7 +88,8 @@ class postfix (
   String                          $maincf_source       = "puppet:///modules/${module_name}/main.cf",
   Boolean                         $manage_conffiles    = true,
   Boolean                         $manage_mailx        = true,
-  Optional[String]                $mastercf_source     = undef,
+  Optional[String]                $mastercf_source     = undef,         # source file to be copied as master.cf
+  Optional[String]                $mastercf_content    = undef,         # provide the Content of master.cf
   Optional[String]                $master_smtp         = undef,         # postfix_master_smtp
   Optional[String]                $master_smtps        = undef,         # postfix_master_smtps
   Optional[String]                $master_submission   = undef,         # postfix_master_submission


### PR DESCRIPTION
Need to provide the content going into master.cf as a string from outside of the module (like in a profile for example)