### PR TITLE
Fix resource dependencies

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -76,10 +76,14 @@ define postfix::transport (
     lens    => 'Postfix_Transport.lns',
     incl    => $file,
     changes => $changes,
-    require => [
-      Package['postfix'],
-      Augeas::Lens['postfix_transport'],
-      ],
-    notify  => Postfix::Hash['/etc/postfix/transport'],
+    require => Augeas::Lens['postfix_transport'],
+  }
+
+  if defined(Package['postfix']) {
+    Package['postfix'] -> Postfix::Transport[$title]
+  }
+
+  if defined(Postfix::Hash['/etc/postfix/transport']) {
+    Postfix::Transport[$title] ~> Postfix::Hash['/etc/postfix/transport']
   }
 }

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -63,10 +63,14 @@ define postfix::virtual (
     incl    => $file,
     lens    => 'Postfix_Virtual.lns',
     changes => $changes,
-    require => [
-      Package['postfix'],
-      Augeas::Lens['postfix_virtual'],
-      ],
-    notify  => Postfix::Hash[$file],
+    require => Augeas::Lens['postfix_virtual'],
+  }
+
+  if defined(Package['postfix']) {
+    Package['postfix'] -> Postfix::Virtual[$title]
+  }
+
+  if defined(Postfix::Hash[$file]) {
+    Postfix::Virtual[$title] ~> Postfix::Hash[$file]
   }
 }

--- a/spec/defines/postfix_hash_spec.rb
+++ b/spec/defines/postfix_hash_spec.rb
@@ -40,7 +40,7 @@ describe 'postfix::hash' do
         it 'should fail' do
           expect {
             is_expected.to contain_file('/tmp/foo')
-          }.to raise_error(Puppet::Error, /got 'foo'/)
+          }.to raise_error(Puppet::Error, /, got /)
         end
       end
 

--- a/spec/defines/postfix_transport_spec.rb
+++ b/spec/defines/postfix_transport_spec.rb
@@ -63,7 +63,7 @@ describe 'postfix::transport' do
         it 'should fail' do
           expect {
             is_expected.to contain_augeas('Postfix transport - foo')
-          }.to raise_error(Puppet::Error, /got 'baz'/)
+          }.to raise_error(Puppet::Error, /, got /)
         end
       end
 

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -58,7 +58,7 @@ describe 'postfix::virtual' do
         it 'should fail' do
           expect {
             is_expected.to contain_augeas('Postfix virtual - foo')
-          }.to raise_error(Puppet::Error, /got 'baz'/)
+          }.to raise_error(Puppet::Error, /, got /)
         end
       end
 


### PR DESCRIPTION
Dependencies must be set only if the resources exist in the catalog.
For some weird reason, this worked in Puppet 4 (and shouldn't have).