### PR TITLE
Install /usr/sbin/sendmail alternative on RedHat

### DIFF
--- a/manifests/conffile.pp
+++ b/manifests/conffile.pp
@@ -21,7 +21,7 @@
 #
 # [*mode*]
 #   The file permissions of the file.
-#   Defaults to 0644
+#   Defaults to 0640
 #
 # [*options*]
 #   Hash with options to use in the template
@@ -48,7 +48,7 @@ define postfix::conffile (
   Variant[Array[String], String, Undef]  $source   = undef,
   Optional[String]                       $content  = undef,
   Stdlib::Absolutepath                   $path     = "/etc/postfix/${name}",
-  String                                 $mode     = '0644',
+  String                                 $mode     = '0640',
   Hash                                   $options  = {},
 ) {
   include ::postfix::params

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -38,7 +38,7 @@ class postfix::files {
   file { '/etc/mailname':
     ensure  => 'file',
     content => "${::fqdn}\n",
-    mode    => '0644',
+    mode    => '0640',
     seltype => $postfix::params::seltype,
   }
 
@@ -72,7 +72,7 @@ class postfix::files {
     ensure  => 'file',
     content => $mastercf_content,
     group   => 'root',
-    mode    => '0644',
+    mode    => '0640',
     owner   => 'root',
     seltype => $postfix::params::seltype,
     source  => $mastercf_source,
@@ -82,7 +82,7 @@ class postfix::files {
   file { '/etc/postfix/main.cf':
     ensure  => 'file',
     group   => 'root',
-    mode    => '0644',
+    mode    => '0640',
     owner   => 'root',
     replace => false,
     seltype => $postfix::params::seltype,

--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -28,6 +28,7 @@ define postfix::hash (
   Enum['present', 'absent']             $ensure='present',
   Variant[Array[String], String, Undef] $source=undef,
   Variant[Array[String], String, Undef] $content=undef,
+  Variant[String[4,4], Undef]           $mode='0640',
 ) {
   include ::postfix::params
 
@@ -47,6 +48,7 @@ define postfix::hash (
     content => $content,
     type    => 'hash',
     path    => $name,
+    mode    => $mode,
   }
 
   Class['postfix'] -> Postfix::Hash[$title]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,7 +126,7 @@ class postfix (
   -> class { '::postfix::packages': }
   -> class { '::postfix::files': }
   ~> class { '::postfix::service': }
-  -> anchor { 'posfix::end': }
+  -> anchor { 'postfix::end': }
 
   if $ldap {
     include ::postfix::ldap

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -11,7 +11,8 @@
 # [*source*] - file source.
 # [*type*]   - type of the postfix map (valid values are cidr, pcre, hash...)
 # [*path*]   - path of the created file. By default it is placed in the
-#              postfix directory
+#              postfix directory.
+# [*mode*]   - mode of the created file. By default it is '0640'.
 #
 # === Requires
 #
@@ -32,6 +33,7 @@ define postfix::map (
   Variant[Array[String], String, Undef] $content = undef,
   String                                $type = 'hash',
   Stdlib::Absolutepath                  $path = "/etc/postfix/${name}",
+  String[4,4]                           $mode = '0640'
 ) {
   include ::postfix::params
 
@@ -61,7 +63,7 @@ define postfix::map (
     content => $content,
     owner   => 'root',
     group   => 'postfix',
-    mode    => '0644',
+    mode    => $mode,
     require => Package['postfix'],
     notify  => $manage_notify,
   }
@@ -72,7 +74,7 @@ define postfix::map (
       path    => "${path}.db",
       owner   => 'root',
       group   => 'postfix',
-      mode    => '0644',
+      mode    => $mode,
       require => [File["postfix map ${name}"], Exec["generate ${name}.db"]],
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,4 +11,11 @@ class postfix::service {
     hasstatus => true,
     restart   => $::postfix::params::restart_cmd,
   }
+  if $::osfamily == 'RedHat' {
+    exec { 'alternatives --set mta /usr/sbin/sendmail.postfix':
+      require => Service['postfix'],
+      path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+      unless  => 'test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix',
+    }
+  }
 }

--- a/spec/classes/postfix_augeas_spec.rb
+++ b/spec/classes/postfix_augeas_spec.rb
@@ -27,7 +27,7 @@ describe 'postfix::augeas' do
         :ensure       => 'present',
         :lens_content => %r{Parses /etc/postfix/virtual},
         :test_content => %r{Provides unit tests and examples for the <Postfix_Virtual> lens.},
-        :stock_since  => '1.0.0',
+        :stock_since  => '1.7.0',
       }) }
     end
   end


### PR DESCRIPTION
Closes: #195, #124 

Debian-based distros only allow one MTA to be installed, so installing postfix will uninstall any previously-installed MTA.

Redhat-based distros, however, allow multiple MTA's to be concurrently installed, and use the [alternatives](https://linux.die.net/man/8/alternatives) mechanism to select which of them should provide the `/usr/sbin/sendmail` binary.

This PR also fixes a [minor spelling error](https://github.com/camptocamp/puppet-postfix/commit/6e71f436440c99e7237c7b7aa57fbeb517ae52af) in the [manifests/init.pp](https://github.com/camptocamp/puppet-postfix/blob/master/manifests/init.pp#L129) file, and ensures that map files (which may contain sensitive passwords) are not globally readable by default.

