### PR TITLE
command line mail requires world readable main.cf

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -83,7 +83,7 @@ class postfix::files {
   file { '/etc/postfix/main.cf':
     ensure  => 'file',
     group   => 'root',
-    mode    => '0640',
+    mode    => '0644',
     owner   => 'root',
     replace => false,
     seltype => $postfix::params::seltype,


### PR DESCRIPTION
I am running Debian - Raspbian 'stretch' on a raspberry-pi.

I am unable to send mail from command line unless main.cf is world readable. I did try changing group to paostfix with same resutls. command line email always failed. There is no seliunx on the device. below is my transaction record with private info changed.

`pi@redacted:/etc/postfix $ ls -l m*.cf
-rw-r----- 1 root root 1686 Jan 17 14:24 main.cf
-rw-r----- 1 root root 4034 Jan 17 16:37 master.cf
pi@redacted:/etc/postfix $ echo "test" | mailx -s "test" anonymous@mail.com
send-mail: fatal: open /etc/postfix/main.cf: Permission denied
Can't send mail: sendmail process failed with error code 75
pi@redacted:/var/log $ sendmail anonymous@mail.com < /tmp/example.txt 
sendmail: fatal: open /etc/postfix/main.cf: Permission denied
pi@redacted:/etc/postfix $ sudo chmod o+r main.cf
pi@redacted:/etc/postfix $ echo "test" | mailx -s "test" anonymous@mail.com
pi@redacted:/var/log $ sendmail anonymous@mail.com < /tmp/example.txt `