### PR TITLE
Unbreak sendmail

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -39,7 +39,7 @@ class postfix::files {
   file { '/etc/mailname':
     ensure  => 'file',
     content => "${::fqdn}\n",
-    mode    => '0640',
+    mode    => '0644',
     seltype => $postfix::params::seltype,
   }
 
@@ -73,7 +73,7 @@ class postfix::files {
     ensure  => 'file',
     content => $mastercf_content,
     group   => 'root',
-    mode    => '0640',
+    mode    => '0644',
     owner   => 'root',
     seltype => $postfix::params::seltype,
     source  => $mastercf_source,

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -83,7 +83,7 @@ class postfix::files {
   file { '/etc/postfix/main.cf':
     ensure  => 'file',
     group   => 'root',
-    mode    => '0640',
+    mode    => '0644',
     owner   => 'root',
     replace => false,
     seltype => $postfix::params::seltype,


### PR DESCRIPTION
The sendmail command was recently broken: https://github.com/camptocamp/puppet-postfix/pull/199#issuecomment-361594549

This Pull-Request unbreaks the sendmail command and relax some permissions which where changed from the default to more restrictive ones.