### PR TITLE
Fixes postmap when ensure=absent

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -79,8 +79,13 @@ define postfix::map (
     }
   }
 
+  $generate_cmd = $ensure ? {
+    'absent'  => "rm ${path}.db",
+    'present' => "postmap ${path}",
+  }
+
   exec {"generate ${name}.db":
-    command     => "postmap ${path}",
+    command     => $generate_cmd,
     path        => $::path,
     #creates    => "${name}.db", # this prevents postmap from being run !
     refreshonly => true,

--- a/spec/defines/postfix_map_spec.rb
+++ b/spec/defines/postfix_map_spec.rb
@@ -93,7 +93,7 @@ describe 'postfix::map' do
         it { is_expected.to contain_file('postfix map foo').with_ensure('absent') }
         it { is_expected.to contain_file('postfix map foo').without_notify }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('absent') }
-        it { is_expected.to contain_exec('generate foo.db') }
+	it { is_expected.to contain_exec('generate foo.db').with(:command => 'rm /etc/postfix/foo.db') }
       end
 
       context 'when using pcre type' do


### PR DESCRIPTION
Fixes an issue where if a postfix map $ensure is 'absent' the postmap exec resource causes puppet runs to fail.

Tried to get this annoying bug fixed a couple of years ago (https://github.com/camptocamp/puppet-postfix/pull/151), I see it's still sitting there. Hopefully I'll have more luck this time. Can this be merged?