### PR TITLE
Moved Exec['newaliases'] to services so it could be run after service restart

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -52,13 +52,6 @@ class postfix::files {
     seltype => $postfix::params::aliasesseltype,
   }
 
-  # Aliases
-  exec { 'newaliases':
-    command     => '/usr/bin/newaliases',
-    refreshonly => true,
-    subscribe   => File['/etc/aliases'],
-  }
-
   # Config files
   if $mastercf_source {
     $mastercf_content = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,6 +11,13 @@ class postfix::service {
     hasstatus => true,
     restart   => $::postfix::params::restart_cmd,
   }
+  # Aliases
+  exec { 'newaliases':
+    command     => '/usr/bin/newaliases',
+    refreshonly => true,
+    subscribe   => File['/etc/aliases'],
+    require     => Service['postfix'],
+  }
   if $::osfamily == 'RedHat' {
     alternatives { 'mta':
       path    => '/usr/sbin/sendmail.postfix',


### PR DESCRIPTION
This should fix the newalias issues found in the following tickets: #192 #136 