### PR TITLE
Add missing parameter breaking SLES support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,7 @@ class postfix::params {
 
     'Suse': {
       $seltype = undef
+      $aliasesseltype = undef
 
       $mailx_package = 'mailx'
 


### PR DESCRIPTION
Without the `$aliasesseltype = undef` each puppet run breaks with `unknown variable`. Please add this small fix to reenable usage on SLES.

Thanks!