### PR TITLE
Support for Alpine Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,7 +53,21 @@ class postfix::params {
     }
 
     default: {
-      fail "Unsupported OS family '${::osfamily}'"
+      case $::operatingsystem {
+        'Alpine': {
+            $aliasesseltype = undef
+            $seltype = undef
+
+            $restart_cmd = '/etc/init.d/postfix reload'
+
+            $mailx_package = 'mailx'
+
+            $master_os_template = "${module_name}/master.cf.debian.erb"
+        }
+        default: {
+          fail "Unsupported OS family '${::osfamily}' and OS '${::operatingsystem}'"
+        }
+      }
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,9 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "Alpine"
     }
   ]
 }


### PR DESCRIPTION
Simple changes in params.pp to support Alpine Linux (osfamily=Linux, operatingsystem=Alpine).