### PR TITLE
WIP: Debian build fix [try]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-8"
+    env:
+      - BEAKER_set="debian-8"
+      - DEBIAN_FRONTEND=noninteractive
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
   - rvm: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,18 @@ matrix:
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-6"
+    env:
+      - BEAKER_set="debian-6"
+      - DEBIAN_FRONTEND=noninteractive
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
   - rvm: default
     sudo: required
     dist: trusty
     services: docker
-    env: BEAKER_set="debian-7"
+    env:
+      - BEAKER_set="debian-7"
+      - DEBIAN_FRONTEND=noninteractive
     bundler_args:
     script: sudo service docker restart ; sleep 10 && bundle exec rspec spec/acceptance/*_spec.rb
   - rvm: default


### PR DESCRIPTION
- [ ] debian6
- [ ] debian7
- [x] debian8
- [ ] debian9


debian builds are failing because of
```
debconf: delaying package configuration, since apt-utils is not installed
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```

should be fixable by defining `DEBIAN_FRONTEND=noninteractive`

as https://lint.travis-ci.org/ is deprecated i do trial an error to define this env variable for debian builds and test it by simply triggering travis here.

