### PR TITLE
Feature/allow specify master cf content & template

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -9,6 +9,7 @@ class postfix::files {
   $maincf_source       = $postfix::maincf_source
   $mastercf_source     = $postfix::mastercf_source
   $mastercf_content    = $postfix::mastercf_content
+  $mastercf_template   = $postfix::mastercf_template
   $master_smtp         = $postfix::master_smtp
   $master_smtps        = $postfix::master_smtps
   $master_submission   = $postfix::master_submission
@@ -58,6 +59,8 @@ class postfix::files {
     $_mastercf_content = undef
   } elsif $mastercf_content {
     $_mastercf_content = $mastercf_content
+  } elsif $mastercf_template {
+    $_mastercf_content = epp($mastercf_template)
   } else {
     $_mastercf_content = template(
       $postfix::params::master_os_template,

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -8,6 +8,7 @@ class postfix::files {
   $manage_conffiles    = $postfix::manage_conffiles
   $maincf_source       = $postfix::maincf_source
   $mastercf_source     = $postfix::mastercf_source
+  $mastercf_content    = $postfix::mastercf_content
   $master_smtp         = $postfix::master_smtp
   $master_smtps        = $postfix::master_smtps
   $master_submission   = $postfix::master_submission
@@ -54,9 +55,11 @@ class postfix::files {
 
   # Config files
   if $mastercf_source {
-    $mastercf_content = undef
+    $_mastercf_content = undef
+  } elsif $mastercf_content {
+    $_mastercf_content = $mastercf_content
   } else {
-    $mastercf_content = template(
+    $_mastercf_content = template(
       $postfix::params::master_os_template,
       'postfix/master.cf.common.erb'
     )
@@ -64,7 +67,7 @@ class postfix::files {
 
   file { '/etc/postfix/master.cf':
     ensure  => 'file',
-    content => $mastercf_content,
+    content => $_mastercf_content,
     group   => 'root',
     mode    => '0644',
     owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,8 @@
 #
 # [*mastercf_content*]    - (string)
 #
+# [*mastercf_template*]   - (string)
+#
 # [*master_smtp*]         - (string)
 #
 # [*master_smtps*]        - (string)
@@ -94,6 +96,7 @@ class postfix (
   Boolean                         $manage_mailx        = true,
   Optional[String]                $mastercf_source     = undef,
   Optional[String]                $mastercf_content    = undef,
+  Optional[String]                $mastercf_template   = undef,
   Optional[String]                $master_smtp         = undef,         # postfix_master_smtp
   Optional[String]                $master_smtps        = undef,         # postfix_master_smtps
   Optional[String]                $master_submission   = undef,         # postfix_master_submission
@@ -118,8 +121,14 @@ class postfix (
   Boolean                         $service_enabled     =  true,
 ) inherits postfix::params {
 
-  if ($mastercf_source and $mastercf_content) {
-    fail('mastercf_source and mastercf_content are mutually exclusive')
+  if (
+    ($mastercf_source and $mastercf_content) or
+    ($mastercf_source and $mastercf_template) or
+    ($mastercf_content and $mastercf_template) or
+    ($mastercf_source and $mastercf_content and $mastercf_template)
+  ) {
+      fail('mastercf_source, mastercf_content and mastercf_template are mutually exclusive')
+    }
   }
 
   $_smtp_listen = $mailman ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #
 # [*mastercf_source*]     - (string)
 #
+# [*mastercf_content*]    - (string)
+#
 # [*master_smtp*]         - (string)
 #
 # [*master_smtps*]        - (string)
@@ -91,6 +93,7 @@ class postfix (
   Boolean                         $manage_conffiles    = true,
   Boolean                         $manage_mailx        = true,
   Optional[String]                $mastercf_source     = undef,
+  Optional[String]                $mastercf_content    = undef,
   Optional[String]                $master_smtp         = undef,         # postfix_master_smtp
   Optional[String]                $master_smtps        = undef,         # postfix_master_smtps
   Optional[String]                $master_submission   = undef,         # postfix_master_submission
@@ -114,6 +117,10 @@ class postfix (
   String                          $service_ensure      = 'running',
   Boolean                         $service_enabled     =  true,
 ) inherits postfix::params {
+
+  if ($mastercf_source and $mastercf_content) {
+    fail('mastercf_source and mastercf_content are mutually exclusive')
+  }
 
   $_smtp_listen = $mailman ? {
     true    => '0.0.0.0',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,14 +121,11 @@ class postfix (
   Boolean                         $service_enabled     =  true,
 ) inherits postfix::params {
 
-  if (
-    ($mastercf_source and $mastercf_content) or
+  if (($mastercf_source and $mastercf_content) or
     ($mastercf_source and $mastercf_template) or
     ($mastercf_content and $mastercf_template) or
-    ($mastercf_source and $mastercf_content and $mastercf_template)
-  ) {
-      fail('mastercf_source, mastercf_content and mastercf_template are mutually exclusive')
-    }
+    ($mastercf_source and $mastercf_content and $mastercf_template)){
+    fail('mastercf_source, mastercf_content and mastercf_template are mutually exclusive')
   }
 
   $_smtp_listen = $mailman ? {

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -185,10 +185,46 @@ describe 'postfix' do
               skip 'need to write this still'
             end
           end
+          context 'when specifying a custom mastercf_template' do
+            let (:params) { {
+              :mastercf_template => 'testy'
+            } }
+            it 'should do stuff' do
+              skip 'need to write this still'
+            end
+          end
           context 'when specifying a custom mastercf_source and mastercf_content' do
             let (:params) { {
               :mastercf_source => 'testy_1' ,
               :mastercf_content => 'testy_2'
+            } }
+            it 'should fail' do
+              expect { should compile }.to raise_error(/mutually exclusive/)
+            end
+          end
+          context 'when specifying a custom mastercf_source and mastercf_template' do
+            let (:params) { {
+              :mastercf_source => 'testy_1' ,
+              :mastercf_template => 'testy_2'
+            } }
+            it 'should fail' do
+              expect { should compile }.to raise_error(/mutually exclusive/)
+            end
+          end
+          context 'when specifying a custom mastercf_content and mastercf_template' do
+            let (:params) { {
+              :mastercf_content => 'testy_1' ,
+              :mastercf_template => 'testy_2'
+            } }
+            it 'should fail' do
+              expect { should compile }.to raise_error(/mutually exclusive/)
+            end
+          end
+          context 'when specifying a mastercf_source and custom mastercf_content and mastercf_template' do
+            let (:params) { {
+              :mastercf_source => 'testy_1' ,
+              :mastercf_content => 'testy_2' ,
+              :mastercf_template => 'testy_3'
             } }
             it 'should fail' do
               expect { should compile }.to raise_error(/mutually exclusive/)

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -177,6 +177,23 @@ describe 'postfix' do
               skip 'need to write this still'
             end
           end
+          context 'when specifying a custom mastercf_content' do
+            let (:params) { {
+              :mastercf_content => 'testy'
+            } }
+            it 'should do stuff' do
+              skip 'need to write this still'
+            end
+          end
+          context 'when specifying a custom mastercf_source and mastercf_content' do
+            let (:params) { {
+              :mastercf_source => 'testy_1' ,
+              :mastercf_content => 'testy_2'
+            } }
+            it 'should fail' do
+              expect { should compile }.to raise_error(/mutually exclusive/)
+            end
+          end
           context 'when specifying a custom master_smtp' do
             let (:params) { {
               :master_smtp         => "smtp      inet  n       -       -       -       -       smtpd


### PR DESCRIPTION
based upon https://github.com/camptocamp/puppet-postfix/pull/91

now supports master.cf from:
- source (as before)
- content (to allow the user to use their prefered content source
- template name (to still be able to use all this modules variables easily