### PR TITLE
Ensure that map files are regenerated if removed (Fix #161)

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -75,7 +75,8 @@ define postfix::map (
       owner   => 'root',
       group   => 'postfix',
       mode    => $mode,
-      require => [File["postfix map ${name}"], Exec["generate ${name}.db"]],
+      require => File["postfix map ${name}"],
+      notify  => $manage_notify,
     }
   }
 


### PR DESCRIPTION
Ensure that, if a map file is removed but the associated source
file is not touched, the map file is regenerated by puppet.

Tested locally, to ensure that map files have correct permissions with the reversed order of file resource and map generation, and to ensure that map files get correct content created if removed.