### PR TITLE
Allow puppetlabs-stdlib < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=3.2.0 <6.0.0"
     },
     {
       "name": "camptocamp/augeas",


### PR DESCRIPTION
This will allow use with current stdlib from Puppet Forge.