### PR TITLE
Add postfix::mailalias, that creates an email alias and updates the binary version of the local alias database.

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -101,9 +101,8 @@ class postfix::files {
   }
 
   if $manage_root_alias {
-    mailalias {'root':
+    postfix::mailalias {'root':
       recipient => $root_mail_recipient,
-      notify    => Exec['newaliases'],
     }
   }
 

--- a/manifests/mailalias.pp
+++ b/manifests/mailalias.pp
@@ -28,8 +28,9 @@ define postfix::mailalias (
   Variant[String, Array[String]] $recipient,
   Enum['present', 'absent']      $ensure='present',
 ) {
-  mailalias { $name:
+  mailalias { $title:
     ensure    => $ensure,
+    name      => $name,
     recipient => $recipient,
     notify    => Exec['newaliases'],
   }

--- a/manifests/mailalias.pp
+++ b/manifests/mailalias.pp
@@ -1,0 +1,32 @@
+#
+#== Definition: postfix::mailalias
+#
+#Wrapper around Puppet mailalias resource, provides newaliases executable.
+#
+#Parameters:
+#- *name*: the name of the alias.
+#- *ensure*: present/absent, defaults to present.
+#- *recipient*: recipient of the alias.
+#
+#Requires:
+#- Class["postfix"]
+#
+#Example usage:
+#
+#  node "toto.example.com" {
+#
+#    include postfix
+#
+#    postfix::mailalias { "postmaster":
+#      ensure    => present,
+#      recipient => 'foo'
+#  }
+#
+#*/
+define postfix::mailalias ($recipient, $ensure = 'present') {
+    mailalias { $name:
+        ensure    => $ensure,
+        recipient => $recipient,
+        notify    => Exec['newaliases'],
+    }
+}

--- a/manifests/mailalias.pp
+++ b/manifests/mailalias.pp
@@ -1,32 +1,36 @@
+# == Definition: postfix::mailalias
 #
-#== Definition: postfix::mailalias
+# Creates an email alias in the local alias database and updates the binary
+# version of said database.
 #
-#Wrapper around Puppet mailalias resource, provides newaliases executable.
+# === Parameters
 #
-#Parameters:
-#- *name*: the name of the alias.
-#- *ensure*: present/absent, defaults to present.
-#- *recipient*: recipient of the alias.
+# [*name*]      - the alias name. See aliases(5).
+# [*ensure*]    - present/absent, defaults to present.
+# [*recipient*] - where email should be sent.
 #
-#Requires:
-#- Class["postfix"]
+# === Requires
 #
-#Example usage:
+# - Class["postfix"]
 #
-#  node "toto.example.com" {
+# === Examples
 #
-#    include postfix
+#   node "toto.example.com" {
 #
-#    postfix::mailalias { "postmaster":
-#      ensure    => present,
-#      recipient => 'foo'
-#  }
+#     include postfix
 #
-#*/
-define postfix::mailalias ($recipient, $ensure = 'present') {
-    mailalias { $name:
-        ensure    => $ensure,
-        recipient => $recipient,
-        notify    => Exec['newaliases'],
-    }
+#     postfix::mailalias { 'postmaster':
+#       ensure    => present,
+#       recipient => 'foo',
+#     }
+#
+define postfix::mailalias (
+  Variant[String, Array[String]] $recipient,
+  Enum['present', 'absent']      $ensure='present',
+) {
+  mailalias { $name:
+    ensure    => $ensure,
+    recipient => $recipient,
+    notify    => Exec['newaliases'],
+  }
 }


### PR DESCRIPTION
Supersedes #115.