### PR TITLE
Schleuder: port invocation syntax to Schleuder 3.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@
 # [*use_dovecot_lda*]     - (boolean) Whether to setup for Dovecot LDA
 #
 # [*use_schleuder*]       - (2/boolean) Whether to setup for Schleuder
-#                           (2 -> Schleuder 2, true -> Schleuder 3)
+#                           (2 -> Schleuder 2, 3 or true -> Schleuder 3)
 #
 # [*use_sympa*]           - (boolean) Whether to setup for Sympa
 #
@@ -108,7 +108,7 @@ class postfix (
   String                          $smtp_listen         = '127.0.0.1',   # postfix_smtp_listen
   Boolean                         $use_amavisd         = false,         # postfix_use_amavisd
   Boolean                         $use_dovecot_lda     = false,         # postfix_use_dovecot_lda
-  Variant[Integer[2, 2], Boolean] $use_schleuder       = false,         # postfix_use_schleuder
+  Variant[Integer[2, 3], Boolean] $use_schleuder       = false,         # postfix_use_schleuder
   Boolean                         $use_sympa           = false,         # postfix_use_sympa
   String                          $postfix_ensure      = 'present',
   String                          $mailx_ensure        = 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,8 @@
 #
 # [*use_dovecot_lda*]     - (boolean) Whether to setup for Dovecot LDA
 #
-# [*use_schleuder*]       - (boolean) Whether to setup for Schleuder
+# [*use_schleuder*]       - (2/boolean) Whether to setup for Schleuder
+#                           (2 -> Schleuder 2, true -> Schleuder 3)
 #
 # [*use_sympa*]           - (boolean) Whether to setup for Sympa
 #
@@ -107,7 +108,7 @@ class postfix (
   String                          $smtp_listen         = '127.0.0.1',   # postfix_smtp_listen
   Boolean                         $use_amavisd         = false,         # postfix_use_amavisd
   Boolean                         $use_dovecot_lda     = false,         # postfix_use_dovecot_lda
-  Boolean                         $use_schleuder       = false,         # postfix_use_schleuder
+  Variant[Integer[2, 2], Boolean] $use_schleuder       = false,         # postfix_use_schleuder
   Boolean                         $use_sympa           = false,         # postfix_use_sympa
   String                          $postfix_ensure      = 'present',
   String                          $mailx_ensure        = 'present',

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -23,7 +23,7 @@ dovecot   unix  -       n       n       -       -       pipe
 <% end -%>
 <% if @use_schleuder %>
 schleuder  unix  -       n       n       -       -       pipe
-  flags=DRhu user=schleuder argv=/usr/bin/schleuder ${user}
+  flags=DRhu user=schleuder argv=/usr/bin/schleuder work ${recipient}
 <% end -%>
 <% if @use_sympa %>
 sympa        unix  -       n       n       -       -       pipe

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -22,8 +22,13 @@ dovecot   unix  -       n       n       -       -       pipe
   flags=DRhu user=<%= @mail_user %>:<%= @mail_user %> argv=/usr/lib/dovecot/deliver -d ${recipient}
 <% end -%>
 <% if @use_schleuder %>
+<% if @use_schleuder == 2 %>
+schleuder  unix  -       n       n       -       -       pipe
+  flags=DRhu user=schleuder argv=/usr/bin/schleuder ${user}
+<% else %>
 schleuder  unix  -       n       n       -       -       pipe
   flags=DRhu user=schleuder argv=/usr/bin/schleuder work ${recipient}
+<% end -%>
 <% end -%>
 <% if @use_sympa %>
 sympa        unix  -       n       n       -       -       pipe


### PR DESCRIPTION
Schleuder 2.x has been deprecated for a while. It's not maintained
anymore, has obsolete dependencies, and has been superseded by
Schleuder 3.

The new syntax is documented on
https://schleuder.org/schleuder/docs/server-admins.html#postfix