### PR TITLE
update mta.pp

### DIFF
--- a/manifests/mta.pp
+++ b/manifests/mta.pp
@@ -26,9 +26,9 @@
 #   }
 #
 class postfix::mta (
-  Pattern[/^\S+(?:,\s*\S+)*$/]               $mydestination = $postfix::mydestination,
-  Pattern[/^(?:\S+?(?:(?:,\s)|(?:\s))?)*$/]  $mynetworks    = $postfix::mynetworks,
-  Pattern[/^\S+$/]                           $relayhost     = $postfix::relayhost,
+  Pattern[/^\S+(?:,\s*\S+)*$/]                 $mydestination = $postfix::mydestination,
+  Pattern[/^(?:\S+?(?:(?:,\s+)|(?:\s+))?)*$/]  $mynetworks    = $postfix::mynetworks,
+  Pattern[/^\S+$/]                             $relayhost     = $postfix::relayhost,
 ) {
 
   # If direct is specified then relayhost should be blank


### PR DESCRIPTION
It allows white spaces between host. Why:
Current status:
for string: 10.42.0.1/32 10.42.0.2/32 *double space* 10.42.0.3/32 10.42.0.4/32 we got error:
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Wrong value for $mynetworks

it's okey cause we know where is problem. (regex: no match)

for string 10.42.0.1/32 10.42.0.2/32 10.42.0.3/32 *double space* 10.42.0.4/32 we got error:
Info: Loading facts
Error: Could not retrieve catalog from remote server: Connection reset by peer
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

That's all, there is no info where is a problem. It's because regex check take too long.
here is sample code to test:
`#!/usr/bin/env ruby
/^(?:\S+?(?:(?:,\s)|(?:\s))?)*$/.match("10.42.0.1/32 10.42.0.2/32 10.42.0.3/32  10.42.0.4/32")`