### PR TITLE
Introduce new parameter 'config' for adding configuration using hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Example: 'hash:/etc/other_aliases'.
 ##### `configs`
 
 A hash containing optional configuration values for main.cf. The values are configured using postfix::config.  
-Default: Undefined.  
-Example: 'message_size_limit': {'value': '51200000'}.
+Default: An empty hash.  
+Example: '{message_size_limit': {'value': '51200000'}}.
 
 ##### `inet_interfaces`
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ A string defining the location of the alias map file.
 Default: 'hash:/etc/aliases'.  
 Example: 'hash:/etc/other_aliases'.
 
+##### `configs`
+
+A hash containing optional configuration values for main.cf. The values are configured using postfix::config.  
+Default: Undefined.  
+Example: 'message_size_limit': {'value': '51200000'}.
+
 ##### `inet_interfaces`
 
 A string defining the network interfaces that Postfix will listen on.  

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 #
 # [*alias_maps*]          - (string)
 #
-# [*configs*]              - (hash)
+# [*configs*]             - (hash)
 #
 # [*inet_interfaces*]     - (string)
 #
@@ -81,7 +81,7 @@
 #
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
-  Optional[Hash]                  $configs             = undef,
+  Optional[Hash]                  $configs             = {},
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,
@@ -128,9 +128,7 @@ class postfix (
     true  => "${alias_maps}, ldap:/etc/postfix/ldap-aliases.cf",
   }
 
-  if $configs {
-    create_resources('::postfix::config', $configs)
-  }
+  create_resources('::postfix::config', $configs)
 
   anchor { 'postfix::begin': }
   -> class { '::postfix::packages': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 #
 # [*alias_maps*]          - (string)
 #
+# [*configs*]              - (hash)
+#
 # [*inet_interfaces*]     - (string)
 #
 # [*inet_protocols*]      - (string)
@@ -79,6 +81,7 @@
 #
 class postfix (
   String                          $alias_maps          = 'hash:/etc/aliases',
+  Optional[Hash]                  $configs             = undef,
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
   Boolean                         $ldap                = false,
@@ -123,6 +126,10 @@ class postfix (
   $all_alias_maps = $ldap ? {
     false => $alias_maps,
     true  => "${alias_maps}, ldap:/etc/postfix/ldap-aliases.cf",
+  }
+
+  if $configs {
+    create_resources('::postfix::config', $configs)
   }
 
   anchor { 'postfix::begin': }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -302,6 +302,16 @@ describe 'postfix' do
               is_expected.not_to contain_package('mailx')
             end
           end
+          context 'when config hash is used' do
+            let (:params) { {
+              :configs => {
+                'message_size_limit' => {
+                  'value' => '51200000'
+              } } } }
+            it 'should update master.cf with the specified contents' do
+              is_expected.to contain_postfix__config('message_size_limit').with_value('51200000')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
With configs hash user can define configuration values in hiera.

This is a simplified replacement for https://github.com/camptocamp/puppet-postfix/pull/232