### PR TITLE
Add `mailalias_core` to dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,12 +3,8 @@ fixtures:
     "augeas_core":
       "repo": "puppetlabs/augeas_core"
       "puppet_version": ">= 6.0.0"
-    "mailalias_core":
-      "repo": "puppetlabs/mailalias_core"
-      "puppet_version": ">= 6.0.0"
   repositories:
     "augeas": "https://github.com/camptocamp/puppet-augeas.git"
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     "alternatives": "https://github.com/voxpupuli/puppet-alternatives.git"
-  symlinks:
-    "postfix": "#{source_dir}"
+    "mailalias_core": "https://github.com/puppetlabs/puppetlabs-mailalias_core.git"

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/camptocamp/puppet-postfix/issues",
   "description": "Postfix Module for Puppet",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0" }
+    {"name":"puppet","version_requirement":">= 4.10.0 < 7.0.0" }
   ],
   "dependencies": [
     {
@@ -23,6 +23,10 @@
     {
       "name": "puppet/alternatives",
       "version_requirement": ">=2.0.0 <3.0.0"
+    },
+    {
+      "name": "puppetlabs/mailalias_core",
+      "version_requirement": ">=1.0.5 <2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
`mailalias_core` is [not bundled](https://puppet.com/docs/puppet/6.3/type.html#type-modules-available-on-the-forge) with Puppet 6 so needs to be listed as a
dependency.

The first release only claimed puppet 6 support, but since `1.0.5`
puppet 4 and 5 are also supported.