### PR TITLE
Allow `Sensitive` postfix::hash/map content

### DIFF
--- a/manifests/hash.pp
+++ b/manifests/hash.pp
@@ -27,7 +27,7 @@
 define postfix::hash (
   Enum['present', 'absent']             $ensure='present',
   Variant[Array[String], String, Undef] $source=undef,
-  Variant[Array[String], String, Undef] $content=undef,
+  Optional[Variant[Sensitive[String],String]] $content = undef,
   Variant[String[4,4], Undef]           $mode='0640',
 ) {
   include ::postfix::params

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -30,7 +30,7 @@
 define postfix::map (
   Enum['present', 'absent']             $ensure = 'present',
   Variant[Array[String], String, Undef] $source = undef,
-  Variant[Array[String], String, Undef] $content = undef,
+  Optional[Variant[Sensitive[String],String]] $content = undef,
   String                                $type = 'hash',
   Stdlib::Absolutepath                  $path = "/etc/postfix/${name}",
   String[4,4]                           $mode = '0640'


### PR DESCRIPTION
This allows `Sensitive` content to be used.  eg.
```puppet
postfix::hash { '/etc/postfix/sasl_passwd':
  ensure  => present,
  content => Sensitive("#Destination                Credentials\n[${relay_host}]            ${username}:${password}"),
}
```

`File` will then redact the content
```
Notice: /Stage[main]/Base::Mail/Postfix::Hash[/etc/postfix/sasl_passwd]/Postfix::Map[/etc/postfix/sasl_passwd]/File[postfix map /etc/postfix/sasl_passwd]/content: [diff redacted]
Notice: /Stage[main]/Base::Mail/Postfix::Hash[/etc/postfix/sasl_passwd]/Postfix::Map[/etc/postfix/sasl_passwd]/File[postfix map /etc/postfix/sasl_passwd]/content: changed [redacted] to [redacted]
```