### PR TITLE
Allow `puppetlabs/stdlib` 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <6.0.0"
+      "version_requirement": ">=4.13.0 <7.0.0"
     },
     {
       "name": "camptocamp/augeas",


### PR DESCRIPTION
stdlib 6.0.0 is due to be released soon.
This module does not use the updated `merge` function.

(Also bumped minimum version to 4.13.0 as that's the version
that introduced the `Stdlib::Absolutepath` type.)

See
https://github.com/puppetlabs/puppetlabs-stdlib/blob/217068f97edd2396ce37ac8c1bd7e23da621d6be/CHANGELOG.md#supported-release-600
https://tickets.puppetlabs.com/browse/MODULES-9017