### PR TITLE
Use concat to generate map files

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,7 @@ fixtures:
   repositories:
     "augeas": "https://github.com/camptocamp/puppet-augeas.git"
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "concat": "https://github.com/puppetlabs/puppetlabs-concat.git"
     "alternatives": "https://github.com/voxpupuli/puppet-alternatives.git"
   symlinks:
     "postfix": "#{source_dir}"

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -56,16 +56,27 @@ define postfix::map (
     }
   }
 
-  file { "postfix map ${name}":
+  concat { $path:
     ensure  => $ensure,
-    path    => $path,
-    source  => $source,
-    content => $content,
+    warn    => true,
     owner   => 'root',
     group   => 'postfix',
     mode    => $mode,
     require => Package['postfix'],
     notify  => $manage_notify,
+  }
+
+  if $source {
+    concat::fragment { "${name} source":
+      target => $path,
+      source => $source,
+    }
+  }
+  if $content {
+    concat::fragment { "${name} content":
+      target  => $path,
+      content => $content,
+    }
   }
 
   if $type !~ /^(cidr|pcre)$/ {
@@ -75,7 +86,7 @@ define postfix::map (
       owner   => 'root',
       group   => 'postfix',
       mode    => $mode,
-      require => File["postfix map ${name}"],
+      require => Concat[$path],
       notify  => $manage_notify,
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,10 @@
     {
       "name": "puppetlabs/mailalias_core",
       "version_requirement": ">=1.0.5 <2.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">=4.0.0 <7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/defines/postfix_hash_spec.rb
+++ b/spec/defines/postfix_hash_spec.rb
@@ -19,7 +19,7 @@ describe 'postfix::hash' do
         } }
         it 'should fail' do
           expect {
-            is_expected.to contain_file('/tmp/foo')
+            is_expected.to contain_concat('/tmp/foo')
           }.to raise_error
         end
       end
@@ -30,7 +30,7 @@ describe 'postfix::hash' do
         } }
         it 'should fail' do
           expect {
-            is_expected.to contain_file('/tmp/foo')
+            is_expected.to contain_concat('/tmp/foo')
           }.to raise_error(Puppet::Error, /got 'running'/)
         end
       end
@@ -39,7 +39,7 @@ describe 'postfix::hash' do
         let (:title) { 'foo' }
         it 'should fail' do
           expect {
-            is_expected.to contain_file('/tmp/foo')
+            is_expected.to contain_concat('/tmp/foo')
           }.to raise_error(Puppet::Error, /, got /)
         end
       end
@@ -52,7 +52,7 @@ describe 'postfix::hash' do
 
         it 'should fail' do
           expect {
-            is_expected.to contain_file('/tmp/foo')
+            is_expected.to contain_concat('/tmp/foo')
           }.to raise_error(Puppet::Error, /You must provide either 'source' or 'content'/)
         end
       end
@@ -62,11 +62,8 @@ describe 'postfix::hash' do
           :source  => '/tmp/bar',
         } }
 
-        it { is_expected.to contain_file('postfix map /tmp/foo').with(
-          :ensure => 'present',
-          :source => '/tmp/bar'
-        ).without(:content)
-        }
+        it { is_expected.to contain_concat('/tmp/foo').with_ensure('present') }
+        it { is_expected.to contain_concat__fragment('/tmp/foo source').with_source('/tmp/bar') }
         it { is_expected.to contain_file('postfix map /tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
 
@@ -77,20 +74,16 @@ describe 'postfix::hash' do
           :content => 'bar',
         } }
 
-        it { is_expected.to contain_file('postfix map /tmp/foo').with(
-          :ensure  => 'present',
-          :content => 'bar'
-        ).without(:source)
-        }
+        it { is_expected.to contain_concat('/tmp/foo').with_ensure('present') }
+        it { is_expected.to contain_concat__fragment('/tmp/foo content').with_content('bar') }
         it { is_expected.to contain_file('postfix map /tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
       end
 
       context 'when not passing source or content' do
-        it { is_expected.to contain_file('postfix map /tmp/foo').with(
-          :ensure  => 'present'
-        ).without(:source).without(:content)
-        }
+        it { is_expected.to contain_concat('/tmp/foo').with_ensure('present') }
+        it { is_expected.not_to contain_concat__fragment('/tmp/foo source') }
+        it { is_expected.not_to contain_concat__fragment('/tmp/foo content') }
         it { is_expected.to contain_file('postfix map /tmp/foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
       end
@@ -100,7 +93,9 @@ describe 'postfix::hash' do
           :ensure => 'absent',
         } }
 
-        it { is_expected.to contain_file('postfix map /tmp/foo').with_ensure('absent') }
+        it { is_expected.to contain_concat('/tmp/foo').with_ensure('absent') }
+        it { is_expected.not_to contain_concat__fragment('/tmp/foo source') }
+        it { is_expected.not_to contain_concat__fragment('/tmp/foo content') }
         it { is_expected.to contain_file('postfix map /tmp/foo.db').with_ensure('absent') }
         it { is_expected.to contain_exec('generate /tmp/foo.db') }
       end

--- a/spec/defines/postfix_map_spec.rb
+++ b/spec/defines/postfix_map_spec.rb
@@ -19,7 +19,7 @@ describe 'postfix::map' do
         } }
         it 'should fail' do
           expect {
-            is_expected.to contain_file('postfix map foo')
+            is_expected.to contain_concat('/etc/postfix/foo')
           }.to raise_error
         end
       end
@@ -30,7 +30,7 @@ describe 'postfix::map' do
         } }
         it 'should fail' do
           expect {
-            is_expected.to contain_file('postfix map foo')
+            is_expected.to contain_concat('/etc/postfix/foo')
           }.to raise_error(Puppet::Error, /got 'running'/)
         end
       end
@@ -43,7 +43,7 @@ describe 'postfix::map' do
 
         it 'should fail' do
           expect {
-            is_expected.to contain_file('postfix map foo')
+            is_expected.to contain_concat('/etc/postfix/foo')
           }.to raise_error(Puppet::Error, /You must provide either 'source' or 'content'/)
         end
       end
@@ -53,11 +53,9 @@ describe 'postfix::map' do
           :source  => '/tmp/bar',
         } }
 
-        it { is_expected.to contain_file('postfix map foo').with(
-          :ensure => 'present',
-          :source => '/tmp/bar'
-        ).without(:content)
-        }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('present') }
+        it { is_expected.to contain_concat__fragment('foo source').with_source('/tmp/bar') }
+        it { is_expected.not_to contain_concat__fragment('foo content') }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate foo.db') }
       end
@@ -67,20 +65,17 @@ describe 'postfix::map' do
           :content => 'bar',
         } }
 
-        it { is_expected.to contain_file('postfix map foo').with(
-          :ensure  => 'present',
-          :content => 'bar'
-        ).without(:source)
-        }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('present') }
+        it { is_expected.to contain_concat__fragment('foo content').with_content('bar') }
+        it { is_expected.not_to contain_concat__fragment('foo source') }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate foo.db') }
       end
 
       context 'when not passing source or content' do
-        it { is_expected.to contain_file('postfix map foo').with(
-          :ensure  => 'present'
-        ).without(:source).without(:content)
-        }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('present') }
+        it { is_expected.not_to contain_concat__fragment('foo source') }
+        it { is_expected.not_to contain_concat__fragment('foo content') }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('present') }
         it { is_expected.to contain_exec('generate foo.db') }
       end
@@ -90,8 +85,8 @@ describe 'postfix::map' do
           :ensure => 'absent',
         } }
 
-        it { is_expected.to contain_file('postfix map foo').with_ensure('absent') }
-        it { is_expected.to contain_file('postfix map foo').without_notify }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('absent') }
+        it { is_expected.to contain_concat('/etc/postfix/foo').without_notify }
         it { is_expected.to contain_file('postfix map foo.db').with_ensure('absent') }
         it { is_expected.to contain_exec('generate foo.db') }
       end
@@ -101,7 +96,7 @@ describe 'postfix::map' do
           :type => 'pcre',
         } }
 
-        it { is_expected.to contain_file('postfix map foo').with_ensure('present') }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('present') }
         it { is_expected.not_to contain_file('postfix map foo.db') }
       end
 
@@ -110,7 +105,7 @@ describe 'postfix::map' do
           :type => 'cidr',
         } }
 
-        it { is_expected.to contain_file('postfix map foo').with_ensure('present') }
+        it { is_expected.to contain_concat('/etc/postfix/foo').with_ensure('present') }
         it { is_expected.not_to contain_file('postfix map foo.db') }
       end
     end


### PR DESCRIPTION
The source and content parameters can still be used, as before, but this
also allows you to use concat::fragment to generate maps bit by bit.

Supersedes PR #230 