### PR TITLE
Added support for RHEL8 in params.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,18 +4,18 @@ class postfix::params {
       $aliasesseltype = $::operatingsystemmajrelease ? {
         '4'     => 'etc_t',
         /5/     => 'postfix_etc_t',
-        /6|7/   => 'etc_aliases_t',
+        /6|7|8/   => 'etc_aliases_t',
         default => undef,
       }
 
       $seltype = $::operatingsystemmajrelease ? {
-        '4'     => 'etc_t',
-        /5|6|7/ => 'postfix_etc_t',
-        default => undef,
+        '4'       => 'etc_t',
+        /5|6|7|8/ => 'postfix_etc_t',
+        default   => undef,
       }
 
       $restart_cmd = $::operatingsystemmajrelease ? {
-        '7'     => '/bin/systemctl reload postfix',
+        /7|8/   => '/bin/systemctl reload postfix',
         default => '/etc/init.d/postfix reload',
       }
 


### PR DESCRIPTION
RHEL 7 and 8 param settings are compatible (i mean as far as I've experienced so far  ;) )  This PR simply updates the params to account for RHEL 8.  Note: I did not do any adjustments to tests or anything else beyond params -- if you need me to do that just let me know.  Thanks!