### PR TITLE
add retry and proxywrite for debian family OSes

### DIFF
--- a/templates/master.cf.debian.erb
+++ b/templates/master.cf.debian.erb
@@ -41,6 +41,7 @@ trace     unix  -       -       <%= @jail %>       -       0       bounce
 verify    unix  -       -       <%= @jail %>       -       1       verify
 flush     unix  n       -       <%= @jail %>       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
 smtp      unix  -       -       <%= @jail %>       -       -       smtp
 # When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       <%= @jail %>       -       -       smtp
@@ -48,6 +49,7 @@ relay     unix  -       -       <%= @jail %>       -       -       smtp
 #       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
 showq     unix  n       -       <%= @jail %>       -       -       showq
 error     unix  -       -       <%= @jail %>       -       -       error
+retry     unix  -       -       <%= @jail %>       -       -       error
 discard   unix  -       -       <%= @jail %>       -       -       discard
 local     unix  -       n       n       -       -       local
 virtual   unix  -       n       n       -       -       virtual


### PR DESCRIPTION
Fixes #252 

It looks that it is missing `retry` entry only in template of Debian family OSes. It is already present in others families.

It looks that it is missing `proxy_write` entry in RedHat and Debian OSes. 
Accordingly with [proxy_write_maps](http://www.postfix.org/postconf.5.html#proxy_write_map) it looks that it should be present also in CentOS7 at least. But to be preservative, i only added it in Debian family.

