### PR TITLE
Upping version dependency on puppet-alternatives

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet/alternatives",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <4.0.0"
     },
     {
       "name": "puppetlabs/mailalias_core",


### PR DESCRIPTION
Version 3.0.0 of Forge Module puppet-alternatives has been out since March of 2019. It does not appear to have breaking changes. It would be nice for the dependencies on the Postfix module to reflect the latest versions.