### PR TITLE
Add the possibility to manage (or not) aliases

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -15,6 +15,7 @@ class postfix::files {
   $master_bounce_command = $postfix::master_bounce_command
   $master_defer_command  = $postfix::master_defer_command
   $myorigin            = $postfix::myorigin
+  $manage_aliases      = $postfix::manage_aliases
   $manage_root_alias   = $postfix::manage_root_alias
   $root_mail_recipient = $postfix::root_mail_recipient
   $chroot              = $postfix::chroot
@@ -45,12 +46,14 @@ class postfix::files {
   }
 
   # Aliases
-  file { '/etc/aliases':
-    ensure  => 'file',
-    content => "# file managed by puppet\n",
-    notify  => Exec['newaliases'],
-    replace => false,
-    seltype => $postfix::params::aliasesseltype,
+  if $manage_aliases {
+    file { '/etc/aliases':
+      ensure  => 'file',
+      content => "# file managed by puppet\n",
+      notify  => Exec['newaliases'],
+      replace => false,
+      seltype => $postfix::params::aliasesseltype,
+    }
   }
 
   # Config files

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,8 @@
 #
 # [*myorigin*]            - (string)
 #
+# [*manage_aliases*]      - (boolean) Manage /etc/aliases file
+#
 # [*relayhost*]           - (string)
 #
 # [*root_mail_recipient*] - (string)
@@ -109,6 +111,7 @@ class postfix (
   String                          $mydestination       = '$myorigin',   # postfix_mydestination
   String                          $mynetworks          = '127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128', # postfix_mynetworks
   String                          $myorigin            = $::fqdn,
+  Boolean                         $manage_aliases      = true,          # /etc/aliases
   Optional[String]                $relayhost           = undef,         # postfix_relayhost
   Boolean                         $manage_root_alias   = true,
   Variant[Array[String], String]  $root_mail_recipient = 'nobody',      # root_mail_recipient

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,4 +1,7 @@
 class postfix::service {
+
+  $manage_aliases = $postfix::manage_aliases
+
   exec { 'restart postfix after packages install':
     command     => regsubst($::postfix::params::restart_cmd, 'reload', 'restart'),
     refreshonly => true,
@@ -12,11 +15,13 @@ class postfix::service {
     restart   => $::postfix::params::restart_cmd,
   }
   # Aliases
-  exec { 'newaliases':
-    command     => '/usr/bin/newaliases',
-    refreshonly => true,
-    subscribe   => File['/etc/aliases'],
-    require     => Service['postfix'],
+  if $manage_aliases {
+    exec { 'newaliases':
+      command     => '/usr/bin/newaliases',
+      refreshonly => true,
+      subscribe   => File['/etc/aliases'],
+      require     => Service['postfix'],
+    }
   }
   if $::osfamily == 'RedHat' {
     alternatives { 'mta':

--- a/spec/acceptance/postfix_spec.rb
+++ b/spec/acceptance/postfix_spec.rb
@@ -39,5 +39,43 @@ describe 'postfix class' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+
+    describe file('/etc/aliases') do
+      it { is_expected.to exist }
+    end
+  end
+
+  context 'default parameters with manage_aliase as false' do
+    it 'should work idempotently with no errors and with your own configuration of /etc/aliases ' do
+      pp = <<-EOS
+        # Make sure the default mailer is stopped in docker containers
+        if $::operatingsystem == 'Debian' {
+          service { 'exim4':
+            ensure    => stopped,
+            hasstatus => false,
+            before    => Class['postfix'],
+          }
+        }
+        if $::osfamily == 'RedHat' {
+          service { 'sendmail':
+            ensure    => stopped,
+            hasstatus => false,
+            before    => Class['postfix'],
+          }
+        }
+        class { 'postfix':
+          smtp_listen    => 'all',
+          manage_aliases => false,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe file('/etc/aliases') do
+      it { is_expected.not_to exist }
+    end
   end
 end


### PR DESCRIPTION
A short pickup from PR #238 (thx your1p!) to fix #237 to add the possibility to unmanage "/etc/aliases".