### PR TITLE
Fix hardcoded map path

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -113,7 +113,7 @@ define postfix::transport (
     Package['postfix'] -> Postfix::Transport[$title]
   }
 
-  if defined(Postfix::Hash['/etc/postfix/transport']) {
-    Postfix::Transport[$title] ~> Postfix::Hash['/etc/postfix/transport']
+  if defined(Postfix::Hash[$file]) {
+    Postfix::Transport[$title] ~> Postfix::Hash[$file]
   }
 }


### PR DESCRIPTION
The relationship definition for the map path in `Postfix::Transport` was
hardcoded, so that any non-standard `$file` parameter did not create an
automatic refresh of the map, even if it is defined as a
`Postfix::Hash`.

Fixed be replacing the hardcoded string with the `$file` variable, which
means no change with expected behaviour.