### PR TITLE
Adjust postfix::config to use value type for appropriate action

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,9 +27,15 @@
 #     ensure => 'blank',
 #   }
 #
+#   # By value type/size:
+#   postfix::config {
+#     'myorigin':      value => undef  # Rm
+#     'myhostname':    value => 'xyz'  # Set 
+#     'mydestination': value => '',    # Clear
+#   }
 define postfix::config (
-  Optional[String]                   $value  = undef,
-  Enum['present', 'absent', 'blank'] $ensure = 'present',
+  Variant[Undef, String] $value  = undef,
+  Variant[Undef, Enum['present', 'absent', 'blank']] $ensure = undef,
 ) {
 
   if ($ensure == 'present') {
@@ -52,8 +58,20 @@ define postfix::config (
     'blank': {
       $changes = "clear ${name}"
     }
-    default: {
-      fail "Unknown value for ensure '${ensure}'"
+    default: {}
+  }
+
+  if !defined('$changes') {
+    case $value {
+      /^.+$/: {
+        $changes = "set ${name} '${value}'"
+      }
+      /^$/: {
+        $changes = "clear ${name}"
+      }
+      default: {
+        $changes = "rm ${name}"
+      }
     }
   }
 

--- a/spec/defines/postfix_config_spec.rb
+++ b/spec/defines/postfix_config_spec.rb
@@ -13,11 +13,17 @@ describe 'postfix::config' do
         facts
       end
 
-      context 'when not passing value' do
+      context 'when not passing value while ensure present' do
+        let(:params) do
+          {
+            ensure: 'present',
+          }
+        end
+
         it 'fails' do
           expect {
-            is_expected.to contain_augeas("set postfix 'foo'")
-          }.to raise_error
+            is_expected.to contain_augeas("manage postfix 'foo'")
+          }.to raise_error(Exception, %r{can not be empty if ensure = present})
         end
       end
 
@@ -30,8 +36,8 @@ describe 'postfix::config' do
 
         it 'fails' do
           expect {
-            is_expected.to contain_augeas("set postfix 'foo'")
-          }.to raise_error
+            is_expected.to contain_augeas("manage postfix 'foo'")
+          }.to raise_error(Exception, %r{got Tuple})
         end
       end
 
@@ -45,8 +51,8 @@ describe 'postfix::config' do
 
         it 'fails' do
           expect {
-            is_expected.to contain_augeas("set postfix 'foo'")
-          }.to raise_error
+            is_expected.to contain_augeas("manage postfix 'foo'")
+          }.to raise_error(Exception, %r{got Tuple})
         end
       end
 
@@ -60,7 +66,7 @@ describe 'postfix::config' do
 
         it 'fails' do
           expect {
-            is_expected.to contain_augeas("set postfix 'foo'")
+            is_expected.to contain_augeas("manage postfix 'foo'")
           }.to raise_error(Puppet::Error, %r{got 'running'})
         end
       end
@@ -112,6 +118,49 @@ describe 'postfix::config' do
             incl: '/etc/postfix/main.cf',
             lens: 'Postfix_Main.lns',
             changes: 'clear foo',
+          )
+        }
+      end
+
+      # Non ensure checks
+      context 'when not ensuring and value string' do
+        let(:params) do
+          {
+            value: 'bar',
+          }
+        end
+
+        it {
+          is_expected.to contain_augeas("manage postfix 'foo'").with(
+            incl: '/etc/postfix/main.cf',
+            lens: 'Postfix_Main.lns',
+            changes: "set foo 'bar'",
+          )
+        }
+      end
+
+      context 'when not ensuring and value empty' do
+        let(:params) do
+          {
+            value: '',
+          }
+        end
+
+        it {
+          is_expected.to contain_augeas("manage postfix 'foo'").with(
+            incl: '/etc/postfix/main.cf',
+            lens: 'Postfix_Main.lns',
+            changes: 'clear foo',
+          )
+        }
+      end
+
+      context 'when not ensuring and value undef' do
+        it {
+          is_expected.to contain_augeas("manage postfix 'foo'").with(
+            incl: '/etc/postfix/main.cf',
+            lens: 'Postfix_Main.lns',
+            changes: 'rm foo',
           )
         }
       end


### PR DESCRIPTION
Allow create flexible profiles, that managed through hiera

If you do not specify ensure, than analyze $value and act accordingly.
Remove if undef, clear if empty, set if string.
Allows to create hiera managed multitype profiles

mx.yaml
```
---
profile::postfix::virtual_mailbox_domains: 'ldap:/etc/postfix/ldap-vmd.cf'
profile::postfix::virtual_mailbox_maps: 'ldap:/etc/postfix/ldap-vmm.cf'
profile::postfix::virtual_alias_maps: 'ldap:/etc/postfix/ldap-vam.cf'
```
relay.yaml
```
---
profile::postfix::smtpd_sasl_auth_enable: 'yes'
profile::postfix::smtpd_sasl_path: inet:127.0.0.1:5555

profile::postfix::virtual_mailbox_domains: 'ldap:/etc/postfix/ldap-vmd.cf'
profile::postfix::virtual_mailbox_maps: 'ldap:/etc/postfix/ldap-vmm.cf'
profile::postfix::virtual_alias_maps: 'ldap:/etc/postfix/ldap-vam.cf'
```
profile/manifests/postfix.pp
```
class profile::postfix (
  # Auth settings / Not for MX
  Variant[Undef, String] $smtpd_sasl_auth_enable                  = undef,
  Variant[Undef, String] $smtpd_sasl_path                         = undef,

  # Virtual settings
  Variant[Undef, String] $virtual_mailbox_domains                 = undef,
  Variant[Undef, String] $virtual_mailbox_maps                    = undef,
  Variant[Undef, String] $virtual_alias_maps                      = undef,
) {
  include ::postfix

  postfix::config {
    'smtpd_sasl_auth_enable':                    value => $smtpd_sasl_auth_enable;
    'smtpd_sasl_path':                           value => $smtpd_sasl_path;
 
    'virtual_mailbox_domains':                   value => $virtual_mailbox_domains;
    'virtual_mailbox_maps':                      value => $virtual_mailbox_maps;
    'virtual_alias_maps':                        value => $virtual_alias_maps;
  }
}
```