### PR TITLE
init.pp: correct param numbers and use of optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,13 +10,13 @@
 #
 # [*configs*]             - (hash)
 #
-# [*hash*]                - (hash) A hash of postfix::hash resources
+# [*hashes*]              - (hash) A hash of postfix::hash resources
 #
-# [*transport*]           - (hash) A hash of postfix::transport resources
+# [*transports*]          - (hash) A hash of postfix::transport resources
 #
-# [*virtual*]             - (hash) A hash of postfix::virtual resources
+# [*virtuals*]            - (hash) A hash of postfix::virtual resources
 #
-# [*conffile*]             - (hash) A hash of postfix::conffile resources
+# [*conffiles*]           - (hash) A hash of postfix::conffile resources
 #
 # [*amavis_procs*]        - (integer) Number of amavis scanners to spawn
 #
@@ -106,11 +106,11 @@ class postfix (
   Stdlib::Absolutepath            $confdir             = '/etc/postfix',
   String                          $root_group          = 'root',
   String                          $alias_maps          = 'hash:/etc/aliases',
-  Optional[Hash]                  $configs             = {},
-  Optional[Hash]                  $hash                = {},
-  Optional[Hash]                  $transport           = {},
-  Optional[Hash]                  $virtual             = {},
-  Optional[Hash]                  $conffile            = {},
+  Hash                            $configs             = {},
+  Hash                            $hashes              = {},
+  Hash                            $transports          = {},
+  Hash                            $virtuals            = {},
+  Hash                            $conffiles           = {},
   Integer                         $amavis_procs        = 2,
   String                          $inet_interfaces     = 'all',
   String                          $inet_protocols      = 'all',
@@ -130,7 +130,7 @@ class postfix (
   Optional[String]                $master_smtp         = undef,         # postfix_master_smtp
   Optional[String]                $master_smtps        = undef,         # postfix_master_smtps
   Optional[String]                $master_submission   = undef,         # postfix_master_submission
-  Optional[Array[String]]         $master_entries      = undef,         # postfix_master_entries
+  Array[String]                   $master_entries      = [],            # postfix_master_entries
   String                          $master_bounce_command = 'bounce',
   String                          $master_defer_command  = 'bounce',
   Boolean                         $mta                 = false,
@@ -170,11 +170,35 @@ class postfix (
     true  => "${alias_maps}, ldap:${confdir}/ldap-aliases.cf",
   }
 
-  create_resources('::postfix::config', $configs)
-  create_resources('::postfix::transport', $transport)
-  create_resources('::postfix::virtual', $virtual)
-  create_resources('::postfix::hash', $hash)
-  create_resources('::postfix::conffile', $conffile)
+  $configs.each |$key, $value| {
+    postfix::config { $key:
+      * => $value,
+    }
+  }
+
+  $transports.each |$key, $value| {
+    postfix::transport { $key:
+      * => $value,
+    }
+  }
+
+  $virtuals.each |$key, $value| {
+    postfix::virtual { $key:
+      * => $value,
+    }
+  }
+
+  $hashes.each |$key, $value| {
+    postfix::hash { $key:
+      * => $value,
+    }
+  }
+
+  $conffiles.each |$key, $value| {
+    postfix::conffile { $key:
+      * => $value,
+    }
+  }
 
   contain 'postfix::packages'
   contain 'postfix::files'

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -490,10 +490,10 @@ describe 'postfix' do
               is_expected.to contain_postfix__config('message_size_limit').with_value('51200000')
             end
           end
-          context 'when hash hash is used' do
+          context 'when hashes hash is used' do
             let(:params) do
               {
-                hash: {
+                hashes: {
                   '/etc/postfix/transport' => {
                     'ensure' => 'present',
                   },
@@ -505,10 +505,10 @@ describe 'postfix' do
               is_expected.to contain_postfix__hash('/etc/postfix/transport').with_ensure('present')
             end
           end
-          context 'when transport hash is used' do
+          context 'when transports hash is used' do
             let(:params) do
               {
-                transport: {
+                transports: {
                   'local_relay' => {
                     'nexthop' => '[10.12.0.2]:9925',
                   },
@@ -520,10 +520,10 @@ describe 'postfix' do
               is_expected.to contain_postfix__transport('local_relay').with_nexthop('[10.12.0.2]:9925')
             end
           end
-          context 'when virtual hash is used' do
+          context 'when virtuals hash is used' do
             let(:params) do
               {
-                virtual: {
+                virtuals: {
                   'someone@somedomain.tld' => {
                     'destination' => 'internal@ourdomain.tld',
                   },
@@ -535,10 +535,10 @@ describe 'postfix' do
               is_expected.to contain_postfix__virtual('someone@somedomain.tld').with_destination('internal@ourdomain.tld')
             end
           end
-          context 'when conffile hash is used' do
+          context 'when conffiles hash is used' do
             let(:params) do
               {
-                conffile: {
+                conffiles: {
                   'ldapoptions.cf' => {
                     'mode'    => '0640',
                     'options' => {

--- a/templates/master.cf.common.erb
+++ b/templates/master.cf.common.erb
@@ -36,6 +36,4 @@ sympa        unix  -       n       n       -       -       pipe
 sympabounce  unix  -       n       n       -       -       pipe
   flags=R user=sympa argv=/usr/lib/sympa/bin/bouncequeue ${user}
 <% end -%>
-<% if @master_entries %>
 <%= @master_entries.join("\n") %>
-<% end -%>


### PR DESCRIPTION
Parameters used for generating resources should be plural.

Remove incorrect usage of `Optional`.

Also, use loops instead of `create_resources()`.

This is not a backwards-incompatible change because we haven't made a release since these parameters were added.