### PR TITLE
remove unneeded tests; provide error message for raise_error

### DIFF
--- a/spec/defines/postfix_conffile_spec.rb
+++ b/spec/defines/postfix_conffile_spec.rb
@@ -13,20 +13,6 @@ describe 'postfix::conffile' do
         facts
       end
 
-      context 'when passing wrong type for ensure' do
-        let(:params) do
-          {
-            ensure: ['present'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_file('postfix conffile foo')
-          end.to raise_error
-        end
-      end
-
       context 'when passing wrong value for ensure' do
         let(:params) do
           {

--- a/spec/defines/postfix_config_spec.rb
+++ b/spec/defines/postfix_config_spec.rb
@@ -23,36 +23,7 @@ describe 'postfix::config' do
         it 'fails' do
           expect do
             is_expected.to contain_augeas("set postfix 'foo'")
-          end.to raise_error
-        end
-      end
-
-      context 'when passing wrong type for value' do
-        let(:params) do
-          {
-            value: ['bar'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas("set postfix 'foo'")
-          end.to raise_error
-        end
-      end
-
-      context 'when passing wrong type for ensure' do
-        let(:params) do
-          {
-            value: 'bar',
-            ensure: ['present'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas("set postfix 'foo'")
-          end.to raise_error
+          end.to raise_error(Puppet::Error, %r{can not be empty if ensure = present})
         end
       end
 

--- a/spec/defines/postfix_hash_spec.rb
+++ b/spec/defines/postfix_hash_spec.rb
@@ -13,20 +13,6 @@ describe 'postfix::hash' do
         facts
       end
 
-      context 'when passing wrong type for ensure' do
-        let(:params) do
-          {
-            ensure: ['present'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_file('/tmp/foo')
-          end.to raise_error
-        end
-      end
-
       context 'when passing wrong value for ensure' do
         let(:params) do
           {

--- a/spec/defines/postfix_map_spec.rb
+++ b/spec/defines/postfix_map_spec.rb
@@ -20,20 +20,6 @@ describe 'postfix::map' do
         facts
       end
 
-      context 'when passing wrong type for ensure' do
-        let(:params) do
-          {
-            ensure: ['present'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_file('postfix map foo')
-          end.to raise_error
-        end
-      end
-
       context 'when passing wrong value for ensure' do
         let(:params) do
           {

--- a/spec/defines/postfix_transport_spec.rb
+++ b/spec/defines/postfix_transport_spec.rb
@@ -24,50 +24,6 @@ describe 'postfix::transport' do
                     puppetversion: Puppet.version)
       end
 
-      context 'when sending wrong type for destination' do
-        let(:params) do
-          {
-            destination: ['bar'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix transport - foo')
-          end.to raise_error
-        end
-      end
-
-      context 'when sending wrong type for nexthop' do
-        let(:params) do
-          {
-            destination: 'bar',
-            nexthop: ['baz'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix transport - foo')
-          end.to raise_error
-        end
-      end
-
-      context 'when sending wrong type for file' do
-        let(:params) do
-          {
-            destination: 'bar',
-            file: ['baz'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix transport - foo')
-          end.to raise_error
-        end
-      end
-
       context 'when sending wrong value for file' do
         let(:params) do
           {
@@ -80,21 +36,6 @@ describe 'postfix::transport' do
           expect do
             is_expected.to contain_augeas('Postfix transport - foo')
           end.to raise_error(Puppet::Error, %r{, got })
-        end
-      end
-
-      context 'when sending wrong type for ensure' do
-        let(:params) do
-          {
-            destination: 'bar',
-            ensure: ['baz'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix transport - foo')
-          end.to raise_error
         end
       end
 

--- a/spec/defines/postfix_virtual_spec.rb
+++ b/spec/defines/postfix_virtual_spec.rb
@@ -32,35 +32,6 @@ describe 'postfix::virtual' do
         end
       end
 
-      context 'when sending wrong type for destination' do
-        let(:params) do
-          {
-            destination: true,
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix virtual - foo')
-          end.to raise_error
-        end
-      end
-
-      context 'when sending wrong type for file' do
-        let(:params) do
-          {
-            destination: 'bar',
-            file: ['baz'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix virtual - foo')
-          end.to raise_error
-        end
-      end
-
       context 'when sending wrong value for file' do
         let(:params) do
           {
@@ -73,21 +44,6 @@ describe 'postfix::virtual' do
           expect do
             is_expected.to contain_augeas('Postfix virtual - foo')
           end.to raise_error(Puppet::Error, %r{, got })
-        end
-      end
-
-      context 'when sending wrong type for ensure' do
-        let(:params) do
-          {
-            destination: 'bar',
-            ensure: ['baz'],
-          }
-        end
-
-        it 'fails' do
-          expect do
-            is_expected.to contain_augeas('Postfix virtual - foo')
-          end.to raise_error
         end
       end
 


### PR DESCRIPTION
Tests for wrong parameter data types aren't really needed since Puppet will do the type checking itself. These tests also caused warnings because they didn't provide specific error messages to the `raise_error` matcher.

Also, provide error messages to the remaining `raise_error` matches that lacked error messages, to avoid warnings like this:

```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing
the method you are intending to call. Actual error raised was
a Resource Statement, Postfix::... expects a match for Enum['absent',
'present'], got Tuple (line: 5) on node lithium.kenyonralph.com>.
Instead consider provi ding a specific error class or message. This
message can be suppressed by setting:
`RSpec::Expectations.configuration.on_potential_false_positives =
:nothing`. Called from /home/kenyon/git/
puppet-postfix/spec/defines/postfix_virtual_spec.rb:88:in `block (5
levels) in <top (required)>'.
```