### PR TITLE
Add support for managing custom mailalias target

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -334,7 +334,7 @@ Default value: `"puppet:///modules/${module_name}/main.cf"`
 
 Data type: `Boolean`
 
-Manage /etc/aliases file
+Manage $alias_maps file
 
 Default value: `true`
 

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -57,7 +57,7 @@ class postfix::files {
 
   # Aliases
   if $manage_aliases {
-    file { '/etc/aliases':
+    file { regsubst($postfix::alias_maps, '^.*:', ''):
       ensure  => 'file',
       content => "# file managed by puppet\n",
       notify  => Exec['newaliases'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,7 @@
 #   Example: `puppet:///modules/some/other/location/main.cf`.
 #
 # @param manage_aliases
-#   Manage /etc/aliases file
+#   Manage $alias_maps file
 #
 # @param manage_conffiles
 #   A Boolean defining whether the puppet module should replace the configuration files for postfix.
@@ -284,7 +284,7 @@ class postfix (
   Boolean $mailman = false,
   String $mailx_ensure = 'present',
   String $maincf_source = "puppet:///modules/${module_name}/main.cf",
-  Boolean $manage_aliases = true, # /etc/aliases
+  Boolean $manage_aliases = true, # $alias_maps
   Boolean $manage_conffiles = true,
   Boolean $manage_mailname = true,
   Boolean $manage_mailx = true,

--- a/manifests/mailalias.pp
+++ b/manifests/mailalias.pp
@@ -26,6 +26,7 @@ define postfix::mailalias (
     ensure    => $ensure,
     name      => $name,
     recipient => $recipient,
+    target    => regsubst($postfix::alias_maps, '^.*:', ''),
     notify    => Exec['newaliases'],
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,7 +25,7 @@ class postfix::service {
       command     => 'newaliases',
       path        => $facts['path'],
       refreshonly => true,
-      subscribe   => File['/etc/aliases'],
+      subscribe   => File[regsubst($postfix::alias_maps, '^.*:', '')],
       require     => Service['postfix'],
     }
   }

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -56,6 +56,7 @@ describe 'postfix' do
         it { is_expected.to contain_postfix__config('inet_protocols').with_value('all') }
         it { is_expected.to contain_postfix__mailalias('root').with_recipient('nobody') }
         it { is_expected.to contain_mailalias('root').with_recipient('nobody') }
+        it { is_expected.to contain_mailalias('root').with_target('/etc/aliases') }
         it { is_expected.to contain_class('postfix::files') }
         it { is_expected.to contain_class('postfix::packages') }
         it { is_expected.to contain_class('postfix::params') }
@@ -563,6 +564,14 @@ describe 'postfix' do
 
         it 'contains a Mailalias resource directing roots mail to the required user' do
           is_expected.to contain_mailalias('root').with_recipient('foo')
+        end
+      end
+
+      context 'when specifying a custom alias_maps' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        let(:params) { { alias_maps: 'hash:/etc/mail/aliases' } }
+
+        it 'contains a Mailalias resource that target the correct file' do
+          is_expected.to contain_mailalias('root').with_target('/etc/mail/aliases')
         end
       end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request add support for managing custom mailalias target using the `$postfix::alias_maps` variable.

This is particularly useful when the system is using the default postfix target which is `/etc/mail/aliases`.